### PR TITLE
Add doc comments across API

### DIFF
--- a/src/api/cache/cache.go
+++ b/src/api/cache/cache.go
@@ -1,3 +1,6 @@
+// Package cache provides generic in-memory caching utilities for the Labra API.
+// Located at src/api/cache, it stores frequently accessed entities to reduce
+// database lookups.
 package cache
 
 import (
@@ -5,17 +8,21 @@ import (
 	"time"
 )
 
+// Cache stores key-value pairs with an optional TTL. It is thread safe and used
+// by various services to hold frequently accessed objects.
 type Cache[K comparable, V any] struct {
 	ttl    time.Duration
 	mu     sync.RWMutex
 	Values map[K]Item[V]
 }
 
+// Item represents a cached value with its expiration time.
 type Item[V any] struct {
 	expirationTime time.Time
 	Value          V
 }
 
+// NewCache initializes a Cache with the provided TTL.
 func NewCache[K comparable, V any](ttl time.Duration) Cache[K, V] {
 	return Cache[K, V]{
 		ttl:    ttl,
@@ -24,6 +31,7 @@ func NewCache[K comparable, V any](ttl time.Duration) Cache[K, V] {
 	}
 }
 
+// Get returns a cached value and a flag indicating whether it exists.
 func (c *Cache[K, V]) Get(key K) (V, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -33,6 +41,7 @@ func (c *Cache[K, V]) Get(key K) (V, bool) {
 	return value.Value, ok
 }
 
+// GetAll retrieves all values in the cache in no particular order.
 func (c *Cache[K, V]) GetAll() []V {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -45,6 +54,7 @@ func (c *Cache[K, V]) GetAll() []V {
 	return values
 }
 
+// Set adds or replaces a value for the given key and sets its expiration time.
 func (c *Cache[K, V]) Set(key K, val V) {
 	var expirationTime time.Time
 
@@ -61,6 +71,7 @@ func (c *Cache[K, V]) Set(key K, val V) {
 	}
 }
 
+// Delete removes the cached value for the provided key.
 func (c *Cache[K, V]) Delete(key K) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/src/api/cache/edge.go
+++ b/src/api/cache/edge.go
@@ -1,3 +1,5 @@
+// Package cache provides caches for edges, fields, and entities in the API.
+// This file defines an edge-specific cache stored in src/api/cache.
 package cache
 
 import (
@@ -7,12 +9,15 @@ import (
 	"github.com/GoLabra/labra/src/api/entgql/entity"
 )
 
+// ErrEdgesNotFound is returned when requested edges are absent from the cache.
 var (
 	ErrEdgesNotFound = errors.New("edges not found in cache")
 )
 
+// Edge holds cached edges keyed by entity name.
 var Edge Cache[string, []entity.Edge]
 
+// NewEdgeCache initializes the global Edge cache with the given TTL.
 func NewEdgeCache(ttl time.Duration) {
 	Edge = NewCache[string, []entity.Edge](ttl)
 }

--- a/src/api/cache/entity.go
+++ b/src/api/cache/entity.go
@@ -1,3 +1,5 @@
+// Package cache stores entities, fields and edges for quick retrieval. This
+// file contains cache logic specific to entities.
 package cache
 
 import (
@@ -7,14 +9,17 @@ import (
 	"github.com/GoLabra/labra/src/api/entgql/entity"
 )
 
+// ErrEntityNotFound indicates that an entity was not found in the cache.
 var (
 	ErrEntityNotFound = fmt.Errorf("entity not found in cache")
 )
 
+// EntityCache wraps Cache to provide lookups by various unique inputs.
 type EntityCache struct {
 	Cache[string, entity.Entity]
 }
 
+// GetByUniqueInput searches for an entity based on its unique fields.
 func (c *EntityCache) GetByUniqueInput(where entity.EntityWhereUniqueInput) (entity.Entity, bool) {
 	if where.Name != nil {
 		return c.Get(*where.Name)
@@ -32,8 +37,10 @@ func (c *EntityCache) GetByUniqueInput(where entity.EntityWhereUniqueInput) (ent
 	return entity.Entity{}, false
 }
 
+// Entity is the global cache of entities keyed by name.
 var Entity EntityCache
 
+// NewEntityCache initializes the global Entity cache with the provided TTL.
 func NewEntityCache(ttl time.Duration) {
 	Entity = EntityCache{
 		Cache: NewCache[string, entity.Entity](ttl),

--- a/src/api/cache/field.go
+++ b/src/api/cache/field.go
@@ -1,3 +1,5 @@
+// Package cache defines caches for field metadata used by the API. The file is
+// located at src/api/cache.
 package cache
 
 import (
@@ -7,12 +9,15 @@ import (
 	"github.com/GoLabra/labra/src/api/entgql/entity"
 )
 
+// ErrFieldsNotFound is returned when field metadata is missing from the cache.
 var (
 	ErrFieldsNotFound = errors.New("fields not found in cache")
 )
 
+// Field holds cached slices of field definitions keyed by entity name.
 var Field Cache[string, []entity.Field]
 
+// NewFieldCache initializes the global Field cache with a TTL.
 func NewFieldCache(ttl time.Duration) {
 	Field = NewCache[string, []entity.Field](ttl)
 }

--- a/src/api/centrifuge/centrifuge.go
+++ b/src/api/centrifuge/centrifuge.go
@@ -1,3 +1,5 @@
+// Package centrifuge wraps the gocent client used for pushing events to
+// Centrifugo. Files are located in src/api/centrifuge.
 package centrifuge
 
 import (
@@ -12,10 +14,12 @@ const (
 	ErrCentrifugeClientNotSetInContext = "centrifuge client is not set in context"
 )
 
+// MessageContent represents payloads publishable to Centrifugo channels.
 type MessageContent interface {
 	Marshal() ([]byte, error)
 }
 
+// Publish sends the given content to the specified Centrifugo channel.
 func Publish(ctx context.Context, client *gocent.Client, channel string, content any) error {
 	c, err := json.Marshal(content)
 

--- a/src/api/centrifuge/code_generation.go
+++ b/src/api/centrifuge/code_generation.go
@@ -1,3 +1,5 @@
+// Package centrifuge contains helpers for publishing code generation events to
+// Centrifugo. File location: src/api/centrifuge.
 package centrifuge
 
 import (
@@ -7,6 +9,7 @@ import (
 	"github.com/centrifugal/gocent/v3"
 )
 
+// AppStatusEvent enumerates application lifecycle events published to Centrifugo.
 type AppStatusEvent string
 
 const (
@@ -18,12 +21,14 @@ const (
 	AppStatusUp                  AppStatusEvent = "UP"
 )
 
+// CodeGenerationMessage is the payload published for code generation events.
 type CodeGenerationMessage struct {
 	Event     AppStatusEvent `json:"event"`
 	Timestamp time.Time      `json:"timestamp"`
 	Entities  any            `json:"entities,omitempty"`
 }
 
+// PublishAppStatusMessage publishes a code generation status message to Centrifugo.
 func PublishAppStatusMessage(ctx context.Context, client *gocent.Client, event AppStatusEvent, entities any) error {
 	content := CodeGenerationMessage{
 		Event:     event,

--- a/src/api/config/config.go
+++ b/src/api/config/config.go
@@ -1,3 +1,6 @@
+// Package config loads application configuration from environment variables.
+// Located in src/api/config, it centralizes configuration needed by the API
+// services.
 package config
 
 import (
@@ -7,6 +10,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// Config holds environment driven configuration for the API server.
 type Config struct {
 	DSN                  string `env:"DSN,required"`
 	DBDialect            string `env:"DB_DIALECT,required"`
@@ -19,6 +23,7 @@ type Config struct {
 	FileStoragePath      string `env:"FILE_STORAGE_PATH,required"`
 }
 
+// New parses environment variables and returns a populated Config instance.
 func New() (*Config, error) {
 	godotenv.Load()
 

--- a/src/api/constants/constants.go
+++ b/src/api/constants/constants.go
@@ -1,3 +1,5 @@
+// Package constants defines shared constants and enumerations for the Labra
+// backend. It lives in src/api/constants.
 package constants
 
 import (
@@ -6,11 +8,19 @@ import (
 	"github.com/MakeNowJust/heredoc"
 )
 
+// Status represents an application or resource status.
 type Status string
+
+// Role defines a user role name used for authorization.
 type Role string
+
+// Environment indicates the deployment environment such as dev or prod.
 type Environment string
+
+// ContextKey identifies values stored in context.Context.
 type ContextKey string
 
+// Commonly used boolean and string constants.
 var (
 	FalseVal                = false
 	TrueVal                 = true
@@ -29,6 +39,7 @@ var (
 	`)
 )
 
+// Enumerations and configuration constants used throughout the API.
 const (
 	Active     Status = "Active"
 	Inactive   Status = "Inactive"
@@ -63,6 +74,7 @@ const (
 	Prod  Environment = "prod"
 )
 
+// String returns the textual representation of the Status value.
 func (s Status) String() string {
 	switch s {
 	case Active:
@@ -90,6 +102,7 @@ func (s Status) String() string {
 	}
 }
 
+// String returns the role name.
 func (r Role) String() string {
 	switch r {
 	case SuperAdmin:
@@ -99,6 +112,7 @@ func (r Role) String() string {
 	}
 }
 
+// String converts the Environment value to its string form.
 func (env Environment) String() string {
 	switch env {
 	case Local:

--- a/src/api/file/file_manager.go
+++ b/src/api/file/file_manager.go
@@ -1,3 +1,5 @@
+// Package file provides helper types for interacting with file storage. It is
+// located under src/api/file.
 package file
 
 import (
@@ -7,10 +9,12 @@ import (
 	"github.com/GoLabra/labra/src/api/entgql/ent"
 )
 
+// FileManager wraps file storage configuration.
 type FileManager struct {
 	config *config.Config
 }
 
+// SaveFile writes the provided content using a configured storage provider.
 func SaveFile(ctx context.Context, name string, content string) (ent.CreateFileInput, error) {
 	return ent.CreateFileInput{}, nil
 }

--- a/src/api/handler/authenticator.go
+++ b/src/api/handler/authenticator.go
@@ -1,3 +1,6 @@
+// Package handler provides HTTP handlers for authentication and GraphQL
+// operations. This file implements the middleware authenticator and resides in
+// src/api/handler.
 package handler
 
 import (
@@ -13,6 +16,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
+// Authenticator validates JWT tokens and injects user and role into the request context.
 func Authenticator(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 

--- a/src/api/handler/login.go
+++ b/src/api/handler/login.go
@@ -1,3 +1,5 @@
+// Package handler exposes HTTP endpoints for authentication and GraphQL.
+// This file contains the login handler and is located in src/api/handler.
 package handler
 
 import (
@@ -14,12 +16,14 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// LoginFormData represents the JSON body expected by the Login handler.
 type LoginFormData struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
 }
 
 // TODO: 1. sanitize error messages; 2. move to api; 3. add logs;
+// Login authenticates a user and issues a JWT on success.
 func Login(w http.ResponseWriter, r *http.Request) {
 	var (
 		loginFormData LoginFormData

--- a/src/api/handler/playground.go
+++ b/src/api/handler/playground.go
@@ -1,3 +1,5 @@
+// Package handler includes HTTP handlers for the API. This file exposes helper
+// functions for serving a GraphQL playground. Located in src/api/handler.
 package handler
 
 import (
@@ -90,6 +92,7 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 `))
 
 // Handler responsible for setting up the playground
+// Playground returns a handler that serves the GraphQL playground at the given endpoint.
 func Playground(title, endpoint string) http.HandlerFunc {
 	return HandlerWithHeaders(title, endpoint, nil, nil)
 }
@@ -97,6 +100,7 @@ func Playground(title, endpoint string) http.HandlerFunc {
 // HandlerWithHeaders sets up the playground.
 // fetcherHeaders are used by the playground's fetcher instance and will not be visible in the UI.
 // uiHeaders are default headers that will show up in the UI headers editor.
+// HandlerWithHeaders sets up a GraphQL playground with optional default headers.
 func HandlerWithHeaders(
 	title, endpoint string,
 	fetcherHeaders, uiHeaders map[string]string,
@@ -123,6 +127,7 @@ func HandlerWithHeaders(
 }
 
 // endpointHasScheme checks if the endpoint has a scheme.
+// endpointHasScheme checks whether the endpoint includes a URL scheme.
 func endpointHasScheme(endpoint string) bool {
 	u, err := url.Parse(endpoint)
 	return err == nil && u.Scheme != ""
@@ -130,6 +135,7 @@ func endpointHasScheme(endpoint string) bool {
 
 // getSubscriptionEndpoint returns the subscription endpoint for the given
 // endpoint if it is parsable as a URL, or an empty string.
+// getSubscriptionEndpoint derives the WebSocket endpoint for subscriptions.
 func getSubscriptionEndpoint(endpoint string) string {
 	u, err := url.Parse(endpoint)
 	if err != nil {

--- a/src/api/handler/session_role.go
+++ b/src/api/handler/session_role.go
@@ -1,3 +1,6 @@
+// Package handler exposes HTTP endpoints for authentication and GraphQL.
+// This file contains logic for changing a user's active role and is located in
+// src/api/handler.
 package handler
 
 import (
@@ -11,10 +14,13 @@ import (
 	"github.com/golang-jwt/jwt"
 )
 
+// ChangeSessionRoleRequest is the expected body for role change requests.
 type ChangeSessionRoleRequest struct {
 	Role string
 }
 
+// ChangeSessionRole signs a new JWT for the currently authenticated user with the
+// requested role.
 func ChangeSessionRole(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	user, ok := ctx.Value(constants.UserContextValue).(*ent.User)

--- a/src/api/handler/signup.go
+++ b/src/api/handler/signup.go
@@ -1,3 +1,5 @@
+// Package handler exposes HTTP endpoints for authentication and GraphQL.
+// This file implements the signup endpoint and is located in src/api/handler.
 package handler
 
 import (
@@ -11,6 +13,7 @@ import (
 	"github.com/GoLabra/labra/src/api/entgql/ent"
 )
 
+// SignupFormData is the expected JSON body for user signup requests.
 type SignupFormData struct {
 	Email     string `json:"email"`
 	Password  string `json:"password"`
@@ -21,6 +24,7 @@ type SignupFormData struct {
 var superAdmin = "SuperAdmin"
 
 // TODO: 1. sanitize error messages; 2. move to api; 3. add logs;
+// Signup registers a new super admin user if none exists and returns status.
 func Signup(w http.ResponseWriter, r *http.Request) {
 	var (
 		signupFormData SignupFormData

--- a/src/api/handler/util.go
+++ b/src/api/handler/util.go
@@ -1,3 +1,5 @@
+// Package handler provides HTTP handlers for authentication and GraphQL.
+// This util file lives in src/api/handler.
 package handler
 
 import (
@@ -5,6 +7,7 @@ import (
 	"net/http"
 )
 
+// writeErrorResponse writes a JSON error message with the provided status code.
 func writeErrorResponse(w http.ResponseWriter, message string, statusCode int) {
 	response, _ := json.Marshal(map[string][]map[string]string{
 		"errors": {

--- a/src/api/hooks/audit_hooks.go
+++ b/src/api/hooks/audit_hooks.go
@@ -1,3 +1,5 @@
+// Package hooks provides ent mutation hooks used across the application. This
+// file defines auditing hooks and lives in src/api/hooks.
 package hooks
 
 import (
@@ -7,6 +9,8 @@ import (
 	"github.com/GoLabra/labra/src/api/entgql/ent"
 )
 
+// CreatedByUpdatedByHook automatically sets createdBy and updatedBy fields on
+// ent mutations when a user is present in the request context.
 func CreatedByUpdatedByHook(next ent.Mutator) ent.Mutator {
 	var currentUserId string
 	return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {

--- a/src/api/interfaces/svc/entity.go
+++ b/src/api/interfaces/svc/entity.go
@@ -1,3 +1,5 @@
+// Package svc exposes service interfaces used by external layers. File path:
+// src/api/interfaces/svc.
 package svc
 
 import (
@@ -6,6 +8,7 @@ import (
 	"github.com/GoLabra/labra/src/api/entgql/entity"
 )
 
+// Entity defines business operations on entities for dependency injection.
 type Entity interface {
 	UpdateEntity(ctx context.Context, where entity.EntityWhereUniqueInput, data entity.UpdateEntityInput) (*entity.Entity, error)
 	CreateEntity(ctx context.Context, data entity.CreateEntityInput) (*entity.Entity, error)

--- a/src/api/strcase/strcase.go
+++ b/src/api/strcase/strcase.go
@@ -1,3 +1,5 @@
+// Package strcase provides string case conversion helpers used during code
+// generation. Located in src/api/strcase.
 package strcase
 
 import (
@@ -13,14 +15,17 @@ import (
 var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
 
+// ToSnake converts a string into snake_case.
 func ToSnake(str string) string {
 	return strcase.ToSnake(str)
 }
 
+// NodeNameToGraphqlName lowers the first letter to create a GraphQL type name.
 func NodeNameToGraphqlName(s string) string {
 	return strings.ToLower(string(s[0])) + s[1:]
 }
 
+// ToLowerCamel converts a string to lowerCamel case.
 func ToLowerCamel(s string) string {
 	camel := ToCamel(s)
 	if len(camel) <= 1 {
@@ -29,6 +34,7 @@ func ToLowerCamel(s string) string {
 	return strings.ToLower(camel[:1]) + camel[1:]
 }
 
+// ToCamel converts a string to Camel case without altering acronyms.
 func ToCamel(s string) string {
 	var camel string
 	words := strings.FieldsFunc(s, isSeparator)
@@ -43,6 +49,7 @@ func ToCamel(s string) string {
 	return strings.ToUpper(camel[:1]) + camel[1:]
 }
 
+// ToPascal converts a string to PascalCase.
 func ToPascal(s string) string {
 	words := strings.FieldsFunc(s, isSeparator)
 	if len(words) == 1 {
@@ -51,10 +58,12 @@ func ToPascal(s string) string {
 	return pascalWords(words)
 }
 
+// ToTitle converts a string to title case.
 func ToTitle(val string) string {
 	return cases.Title(language.English).String(val)
 }
 
+// LowerFirstLetter makes the first letter of the string lower case.
 func LowerFirstLetter(val string) string {
 	return strings.ToLower(val[:1]) + val[1:]
 }

--- a/src/api/subscription/app_status.go
+++ b/src/api/subscription/app_status.go
@@ -1,3 +1,7 @@
+// Package subscription defines pub/sub primitives for the GraphQL API. This
+// file provides helpers for tracking application status and resides in
+// src/api/subscription.
 package subscription
 
+// ApplicationStatus reflects the current overall status of the application.
 var ApplicationStatus AppStatus = AppStatusUp

--- a/src/api/subscription/graphql_subscription.go
+++ b/src/api/subscription/graphql_subscription.go
@@ -1,3 +1,6 @@
+// Package subscription defines pub/sub mechanisms for GraphQL notifications.
+// This file implements an in-memory subscription client and is located in
+// src/api/subscription.
 package subscription
 
 import (
@@ -6,27 +9,32 @@ import (
 	"github.com/GoLabra/labra/src/api/entgql/entity"
 )
 
+// NewGraphqlSubscriptionClient creates a new subscription client instance.
 func NewGraphqlSubscriptionClient() *GraphqlSubscriptionClient {
 	return &GraphqlSubscriptionClient{
 		AppStatusSubscribers: make([]AppStatusSubscriber, 0),
 	}
 }
 
+// GraphqlSubscriptionClient manages subscribers for application status and entity changes.
 type GraphqlSubscriptionClient struct {
 	AppStatusSubscribers []AppStatusSubscriber
 	EntitySubscribers    []EntitySubscriber
 }
 
+// AppStatusSubscriber represents a channel subscribed to application status updates.
 type AppStatusSubscriber struct {
 	Ctx  context.Context
 	Chan chan AppStatus
 }
 
+// EntitySubscriber represents a channel subscribed to entity updates.
 type EntitySubscriber struct {
 	Ctx  context.Context
 	Chan chan []*entity.Entity
 }
 
+// AppStatus enumerates possible status messages sent over subscriptions.
 type AppStatus string
 
 const (
@@ -37,6 +45,7 @@ const (
 	AppStatusFatal      AppStatus = "FATAL"
 )
 
+// PublishAppStatusMessage notifies all subscribers about an application status change.
 func (s *GraphqlSubscriptionClient) PublishAppStatusMessage(appStatus AppStatus) {
 	ApplicationStatus = appStatus
 	for i := 0; i < len(s.AppStatusSubscribers); i++ {
@@ -50,6 +59,7 @@ func (s *GraphqlSubscriptionClient) PublishAppStatusMessage(appStatus AppStatus)
 	}
 }
 
+// PublishEntities notifies subscribers about updated entities.
 func (s *GraphqlSubscriptionClient) PublishEntities(entities []*entity.Entity) {
 	for i := 0; i < len(s.EntitySubscribers); i++ {
 		cgs := s.EntitySubscribers[i]

--- a/src/api/utils/entc.go
+++ b/src/api/utils/entc.go
@@ -1,3 +1,5 @@
+// Package utils contains helper functions for ent code generation. This file is
+// in src/api/utils.
 package utils
 
 import (
@@ -7,6 +9,7 @@ import (
 	"entgo.io/ent/entc/gen"
 )
 
+// ShouldSkip determines if a mutation input should skip a field based on entgql annotations.
 func ShouldSkip(n *gen.Type, skipOp string) bool {
 	ant := &entgql.Annotation{}
 	if err := ant.Decode(n.Annotations[ant.Name()]); err != nil {
@@ -21,6 +24,7 @@ func ShouldSkip(n *gen.Type, skipOp string) bool {
 	return false
 }
 
+// InputEdges filters edges that should be included in mutation input types.
 func InputEdges(m *entgql.MutationDescriptor) []*gen.Edge {
 	inputEdges := make([]*gen.Edge, 0, len(m.Type.Edges))
 	for _, e := range m.Type.Edges {
@@ -32,6 +36,7 @@ func InputEdges(m *entgql.MutationDescriptor) []*gen.Edge {
 	return inputEdges
 }
 
+// CustomFieldName trims _id or _ids suffixes from field names.
 func CustomFieldName(val string) string {
 	val = strings.TrimSuffix(val, "_id")
 	val = strings.TrimSuffix(val, "_ids")

--- a/src/api/utils/os_file_system.go
+++ b/src/api/utils/os_file_system.go
@@ -1,3 +1,5 @@
+// Package utils groups helper utilities used throughout the API. This file
+// provides an abstraction over the OS file system and resides in src/api/utils.
 package utils
 
 import (
@@ -5,19 +7,24 @@ import (
 	"os"
 )
 
-type OSFileSystem struct {
-}
+// OSFileSystem implements filesystem operations using the OS package.
+type OSFileSystem struct{}
 
+// NewOSFileSystem creates an OSFileSystem instance.
 func NewOSFileSystem() OSFileSystem {
 	return OSFileSystem{}
 }
 
+// Open wraps os.Open.
 func (OSFileSystem) Open(name string) (*os.File, error) { return os.Open(name) }
 
+// Create wraps os.Create.
 func (OSFileSystem) Create(name string) (*os.File, error) { return os.Create(name) }
 
+// Exit terminates the process with the given exit code.
 func (OSFileSystem) Exit(code int) { os.Exit(code) }
 
+// Remove wraps os.Remove.
 func (OSFileSystem) Remove(name string) error { return os.Remove(name) }
 
 func (fs OSFileSystem) CopyDirectory(from, to string) error {

--- a/src/api/utils/pointer.go
+++ b/src/api/utils/pointer.go
@@ -1,5 +1,8 @@
+// Package utils groups helper functions used across the API. This file is
+// located in src/api/utils.
 package utils
 
+// P returns a pointer to the provided value.
 func P[T any](val T) *T {
 	return &val
 }

--- a/src/api/utils/schema.go
+++ b/src/api/utils/schema.go
@@ -1,3 +1,5 @@
+// Package utils contains helpers for schema management and generation. The
+// file is located at src/api/utils.
 package utils
 
 import (
@@ -15,10 +17,13 @@ import (
 	"github.com/samborkent/uuidv7"
 )
 
+// NewUUIDV7 generates a new UUID version 7 string.
 func NewUUIDV7() string {
 	return uuidv7.New().String()
 }
 
+// LoadSchema reads ent schemas from disk and populates the cache.
+// See app/entc.go for schema generation details.
 func LoadSchema(config *config.Config) {
 
 	graph, err := entc.LoadGraph(config.EntSchemaPath, &gen.Config{})

--- a/src/app/entc.go
+++ b/src/app/entc.go
@@ -1,5 +1,7 @@
 //go:build ignore
 
+// Binary entc runs ent code generation. It is invoked via go generate in
+// src/app/entc.go.
 package main
 
 import (

--- a/src/app/generate.go
+++ b/src/app/generate.go
@@ -1,3 +1,5 @@
+// Binary generate is used by go:generate directives to regenerate ent and GraphQL code.
+// File path: src/app/generate.go.
 package main
 
 //go:generate rm -rf ./ent/schema

--- a/src/app/main.go
+++ b/src/app/main.go
@@ -1,3 +1,4 @@
+// Binary main starts the Labra server. Located at src/app/main.go.
 package main
 
 import (
@@ -226,7 +227,7 @@ func skipDiffOnAdminEntities(next schema.Differ) schema.Differ {
 			}
 			return false
 		})
-		
+
 		return changes, nil
 	})
 }

--- a/src/app/schema/_admin/additional_edges.go
+++ b/src/app/schema/_admin/additional_edges.go
@@ -1,7 +1,10 @@
+// Package schema defines ent schema extensions used by the admin generator.
+// File path: src/app/schema/_admin/additional_edges.go.
 package schema
 
 import (
 	"entgo.io/ent"
 )
 
+// additionalFileEdges defines edges added to the generated File schema.
 var additionalFileEdges = []ent.Edge{}

--- a/src/app/schema/_admin/external.go
+++ b/src/app/schema/_admin/external.go
@@ -1,3 +1,5 @@
+// Package schema defines ent schemas for admin entities. File path:
+// src/app/schema/_admin/external.go.
 package schema
 
 import (
@@ -7,6 +9,7 @@ import (
 	"entgo.io/ent/schema/field"
 )
 
+// User defines the minimal fields required for external user references.
 type User struct {
 	ent.Schema
 }
@@ -31,6 +34,7 @@ func (User) Fields() []ent.Field {
 	}
 }
 
+// File defines the minimal fields required for external file references.
 type File struct {
 	ent.Schema
 }
@@ -55,6 +59,7 @@ func (File) Fields() []ent.Field {
 	}
 }
 
+// Edges exposes additional edges injected by admin code generation.
 func (File) Edges() []ent.Edge {
 	return additionalFileEdges
 }


### PR DESCRIPTION
## Summary
- add package headers and export comments for caches and util packages
- document HTTP handlers and subscription utilities
- add summaries for main app files and admin schema

## Testing
- `go test ./...` *(fails: Delete Entity tests)*

------
https://chatgpt.com/codex/tasks/task_e_687e058391e0832c8033edeef444476b