### PR TITLE
Add Markdown field type

### DIFF
--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -77,6 +77,8 @@
     "numeral": "^2.0.6",
     "nuqs": "^1.17.6",
     "pluralize": "^8.0.0",
+    "@uiw/react-md-editor": "^3.22.3",
+    "@uiw/react-markdown-preview": "^5.1.0",
     "qs": "^6.14.0",
     "react": "^18",
     "react-dom": "^18",

--- a/src/admin/src/core-features/dynamic-form/form-elements-maps.ts
+++ b/src/admin/src/core-features/dynamic-form/form-elements-maps.ts
@@ -6,6 +6,7 @@ import { DateTimeFormField } from "@/core-features/dynamic-form/form-fields/Date
 import { TimeFormField } from "@/core-features/dynamic-form/form-fields/TimeField";
 import { TextLongFormField } from "@/core-features/dynamic-form/form-fields/TextLongField";
 import { RichTextFormField } from "@/core-features/dynamic-form/form-fields/RichTextField";
+import { MarkdownFormField } from "@/core-features/dynamic-form/form-fields/MarkdownField";
 import { DateFormField } from "@/core-features/dynamic-form/form-fields/DateField";
 import { JSONFormField } from "@/core-features/dynamic-form/form-fields/JSONField";
 import { SelectFormField } from "@/core-features/dynamic-form/form-fields/SelectField";
@@ -18,29 +19,29 @@ import { MultipleChoiceFormField } from "@/core-features/dynamic-form/form-field
 import { TagsSelectFormField } from "@/core-features/dynamic-form/form-fields/TagsSelectField";
 import { PasswordFormField } from "./form-fields/PasswordField";
 
-export const FormElementsMap = { 
-    ShortText: TextShortFormField,
-    LongText: TextLongFormField,
-    RichText: RichTextFormField,
-    Password: PasswordFormField,
-    
-    Number: NumberFormField,
+export const FormElementsMap = {
+  ShortText: TextShortFormField,
+  LongText: TextLongFormField,
+  RichText: RichTextFormField,
+  Markdown: MarkdownFormField,
+  Password: PasswordFormField,
 
-    Boolean: BooleanFormField,
-    BooleanSelect: BooleanSelectFormField,
+  Number: NumberFormField,
 
-    DateTime: DateTimeFormField,
-    Date: DateFormField,
-    Time: TimeFormField,
+  Boolean: BooleanFormField,
+  BooleanSelect: BooleanSelectFormField,
 
-    Json: JSONFormField,
+  DateTime: DateTimeFormField,
+  Date: DateFormField,
+  Time: TimeFormField,
 
-    Select: SelectFormField,
-    TagsSelect: TagsSelectFormField,
+  Json: JSONFormField,
 
-    SingleChoice: SingleChoiceFormField,
-    MultipleChoice: MultipleChoiceFormField,
-    RelationOne: LookupOneFIELDFormField,
-    RelationMany: LookupManyFIELDFormField, 
+  Select: SelectFormField,
+  TagsSelect: TagsSelectFormField,
 
-} as {[key in FormFieldTypes]: React.FC<any>};
+  SingleChoice: SingleChoiceFormField,
+  MultipleChoice: MultipleChoiceFormField,
+  RelationOne: LookupOneFIELDFormField,
+  RelationMany: LookupManyFIELDFormField,
+} as { [key in FormFieldTypes]: React.FC<any> };

--- a/src/admin/src/core-features/dynamic-form/form-fields/MarkdownField.tsx
+++ b/src/admin/src/core-features/dynamic-form/form-fields/MarkdownField.tsx
@@ -1,0 +1,97 @@
+"use client";
+import {
+  FormControl,
+  FormHelperText,
+  FilledInput,
+  InputLabel,
+} from "@mui/material";
+import { get, useFormContext } from "react-hook-form";
+import { ReactNode, useState } from "react";
+import { useFormDynamicContext } from "@/core-features/dynamic-form2/dynamic-form";
+import { useLiteController } from "../lite-controller";
+import { MarkdownEditor } from "@/shared/components/markdown/MarkdownEditor";
+import useId from "@mui/material/utils/useId";
+interface MarkdownFormComponentProps {
+  name: string;
+  label: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  errors?: ReactNode;
+  value: any;
+  onChange: (event: any) => void;
+  onBlur: (event: any) => void;
+}
+export function MarkdownFormComponent(props: MarkdownFormComponentProps) {
+  const {
+    name,
+    label,
+    placeholder,
+    disabled,
+    errors,
+    value,
+    onChange,
+    onBlur,
+  } = props;
+  const [focused, setFocused] = useState(false);
+  const id = useId();
+  return (
+    <FormControl
+      fullWidth
+      variant="filled"
+      focused={focused}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+      error={!!errors}
+    >
+      <InputLabel htmlFor={id} id={`${id}-label`}>
+        {label}
+      </InputLabel>
+      <FilledInput
+        fullWidth
+        inputComponent={MarkdownEditor as any}
+        placeholder={placeholder}
+        disabled={disabled}
+        id={id}
+        name={name}
+        value={value ?? ""}
+        onChange={(e) => onChange(e)}
+        sx={{ overflow: "inherit", padding: 0 }}
+      />
+      {errors && <FormHelperText>{errors}</FormHelperText>}
+    </FormControl>
+  );
+}
+interface FormFieldProps {
+  name: string;
+  placeholder?: string;
+  label: string;
+  disabled?: boolean;
+  hide?: boolean;
+  required?: boolean;
+}
+export function MarkdownFormField(props: FormFieldProps) {
+  useFormDynamicContext(props.name, { disabled: props.disabled });
+  const formContext = useFormContext();
+  const formControllerHandler = useLiteController({
+    name: props.name,
+    control: formContext.control,
+    disabled: props.disabled,
+  });
+  useFormDynamicContext(props.name, {
+    disabled: formControllerHandler.disabled,
+  });
+  if (props.hide) {
+    return null;
+  }
+  const errors = get(formContext.formState.errors, props.name);
+  return (
+    <MarkdownFormComponent
+      label={props.label}
+      placeholder={props.placeholder}
+      required={props.required}
+      errors={errors?.message as string}
+      {...formControllerHandler}
+    />
+  );
+}

--- a/src/admin/src/features/content-manager/use-content-manager-filter-dialog.tsx
+++ b/src/admin/src/features/content-manager/use-content-manager-filter-dialog.tsx
@@ -1,86 +1,162 @@
-
 import { FieldScalarTypes } from "@/types/field-type-descriptor";
 import { useMemo } from "react";
 import { Field } from "@/lib/apollo/graphql.entities";
-import { AdvancedFilter, AdvanedFilterOperator, AdvancedFilterProperty } from "@/core-features/dynamic-filter/filter";
+import {
+  AdvancedFilter,
+  AdvanedFilterOperator,
+  AdvancedFilterProperty,
+} from "@/core-features/dynamic-filter/filter";
 import { useDialog } from "@/hooks/use-dialog";
 import { SearchField } from "./content-manager-search";
-import { containsFoldOperator, containsOperator, hasPrefixOperator, hasSufixOperator, eqStringFoldOperator, eqStringOperator, neqOperator, eqNumberOperator, neqNumberOperator, greaterThanNumberOperator, greaterThanOrEqualNumberOperator, lessThanNumberOperator, lessThanOrEqualNumberOperator, greaterThanDateTimeOperator, greaterThanOrEqualDateTimeOperator, lessThanDateTimeOperator, lessThanOrEqualDateTimeOperator, eqBooleanOperator } from "@/core-features/dynamic-filter/filter-operators";
+import {
+  containsFoldOperator,
+  containsOperator,
+  hasPrefixOperator,
+  hasSufixOperator,
+  eqStringFoldOperator,
+  eqStringOperator,
+  neqOperator,
+  eqNumberOperator,
+  neqNumberOperator,
+  greaterThanNumberOperator,
+  greaterThanOrEqualNumberOperator,
+  lessThanNumberOperator,
+  lessThanOrEqualNumberOperator,
+  greaterThanDateTimeOperator,
+  greaterThanOrEqualDateTimeOperator,
+  lessThanDateTimeOperator,
+  lessThanOrEqualDateTimeOperator,
+  eqBooleanOperator,
+} from "@/core-features/dynamic-filter/filter-operators";
 
 export type FilterProperty2 = Partial<{
-    [key in FieldScalarTypes]: {
-        operators: AdvanedFilterOperator[];
-    };
-}>
+  [key in FieldScalarTypes]: {
+    operators: AdvanedFilterOperator[];
+  };
+}>;
 
 const FieldTypeOperatorsMap: FilterProperty2 = {
-    ShortText: {
-        operators: [containsFoldOperator, containsOperator, hasPrefixOperator, hasSufixOperator, eqStringFoldOperator, eqStringOperator, neqOperator],
-    },
-    LongText: {
-        operators: [containsFoldOperator, containsOperator, hasPrefixOperator, hasSufixOperator, eqStringFoldOperator, eqStringOperator, neqOperator],
-    },
-    Email: {
-        operators: [containsFoldOperator, containsOperator, hasPrefixOperator, hasSufixOperator, eqStringFoldOperator, eqStringOperator, neqOperator],
-    },
-    RichText: {
-        operators: [containsFoldOperator, containsOperator],
-    },
-    Integer: {
-        operators: [eqNumberOperator, neqNumberOperator, greaterThanNumberOperator, greaterThanOrEqualNumberOperator, lessThanNumberOperator, lessThanOrEqualNumberOperator],
-    },
-    Decimal: {
-        operators: [eqNumberOperator, neqNumberOperator, greaterThanNumberOperator, greaterThanOrEqualNumberOperator, lessThanNumberOperator, lessThanOrEqualNumberOperator],
-    },
-    Float: {
-        operators: [eqNumberOperator, neqNumberOperator, greaterThanNumberOperator, greaterThanOrEqualNumberOperator, lessThanNumberOperator, lessThanOrEqualNumberOperator],
-    },
-    DateTime: {
-        operators: [greaterThanDateTimeOperator, greaterThanOrEqualDateTimeOperator, lessThanDateTimeOperator, lessThanOrEqualDateTimeOperator],
-    },
-    Boolean: {
-        operators: [ eqBooleanOperator ],
-    },
-    SingleChoice: {
-        operators: [neqOperator, eqStringOperator],
-    },
-    MultipleChoice: {
-        operators: [neqOperator, eqStringOperator],
-    },
+  ShortText: {
+    operators: [
+      containsFoldOperator,
+      containsOperator,
+      hasPrefixOperator,
+      hasSufixOperator,
+      eqStringFoldOperator,
+      eqStringOperator,
+      neqOperator,
+    ],
+  },
+  LongText: {
+    operators: [
+      containsFoldOperator,
+      containsOperator,
+      hasPrefixOperator,
+      hasSufixOperator,
+      eqStringFoldOperator,
+      eqStringOperator,
+      neqOperator,
+    ],
+  },
+  Email: {
+    operators: [
+      containsFoldOperator,
+      containsOperator,
+      hasPrefixOperator,
+      hasSufixOperator,
+      eqStringFoldOperator,
+      eqStringOperator,
+      neqOperator,
+    ],
+  },
+  RichText: {
+    operators: [containsFoldOperator, containsOperator],
+  },
+  Markdown: {
+    operators: [containsFoldOperator, containsOperator],
+  },
+  Integer: {
+    operators: [
+      eqNumberOperator,
+      neqNumberOperator,
+      greaterThanNumberOperator,
+      greaterThanOrEqualNumberOperator,
+      lessThanNumberOperator,
+      lessThanOrEqualNumberOperator,
+    ],
+  },
+  Decimal: {
+    operators: [
+      eqNumberOperator,
+      neqNumberOperator,
+      greaterThanNumberOperator,
+      greaterThanOrEqualNumberOperator,
+      lessThanNumberOperator,
+      lessThanOrEqualNumberOperator,
+    ],
+  },
+  Float: {
+    operators: [
+      eqNumberOperator,
+      neqNumberOperator,
+      greaterThanNumberOperator,
+      greaterThanOrEqualNumberOperator,
+      lessThanNumberOperator,
+      lessThanOrEqualNumberOperator,
+    ],
+  },
+  DateTime: {
+    operators: [
+      greaterThanDateTimeOperator,
+      greaterThanOrEqualDateTimeOperator,
+      lessThanDateTimeOperator,
+      lessThanOrEqualDateTimeOperator,
+    ],
+  },
+  Boolean: {
+    operators: [eqBooleanOperator],
+  },
+  SingleChoice: {
+    operators: [neqOperator, eqStringOperator],
+  },
+  MultipleChoice: {
+    operators: [neqOperator, eqStringOperator],
+  },
 };
 
-
 interface useContentManagerFilterDialogProps {
-    fields: SearchField[];
+  fields: SearchField[];
 }
-export const useContentManagerFilterDialog = (props: useContentManagerFilterDialogProps) => {
+export const useContentManagerFilterDialog = (
+  props: useContentManagerFilterDialogProps,
+) => {
+  const { fields } = props;
 
-    const { fields } = props;
+  const dialog = useDialog();
 
-    const dialog = useDialog();
+  const filterProperties: AdvancedFilterProperty[] =
+    useMemo((): AdvancedFilterProperty[] => {
+      var result = fields
+        .map((i) => {
+          var operators = FieldTypeOperatorsMap[i.type]?.operators ?? [];
+          if (!operators.length) {
+            return null;
+          }
 
-    const filterProperties: AdvancedFilterProperty[] = useMemo((): AdvancedFilterProperty[] => {
+          return {
+            label: i.label,
+            name: i.name,
+            operators: operators,
+            selectOptions: i.selectOptions ?? [],
+          };
+        })
+        .filter((i) => !!i);
 
-        var result = fields.map(i => {
-
-            var operators = FieldTypeOperatorsMap[i.type]?.operators ?? [];
-            if (!operators.length) {
-                return null;
-            }
-
-            return {
-                label: i.label,
-                name: i.name,
-                operators: operators,
-                selectOptions: i.selectOptions ?? []
-            }
-        }).filter(i => !!i);
-
-        return result;
+      return result;
     }, [fields]);
 
-    return {
-        dialog,
-        filterProperties
-    }
-}
+  return {
+    dialog,
+    filterProperties,
+  };
+};

--- a/src/admin/src/features/content-manager/use-content-manager-form-schema.tsx
+++ b/src/admin/src/features/content-manager/use-content-manager-form-schema.tsx
@@ -1,12 +1,27 @@
-import { Edge, Entity, Field, RelationType } from "@/lib/apollo/graphql.entities";
+import {
+  Edge,
+  Entity,
+  Field,
+  RelationType,
+} from "@/lib/apollo/graphql.entities";
 import { ReactNode, useCallback, useMemo } from "react";
 import { FullEntity } from "@/types/entity";
 import { z } from "zod";
 import { TextShortFormField } from "@/core-features/dynamic-form/form-fields/TextShortField";
 import { TextLongFormField } from "@/core-features/dynamic-form/form-fields/TextLongField";
 import { RichTextFormField } from "@/core-features/dynamic-form/form-fields/RichTextField";
+import { MarkdownFormField } from "@/core-features/dynamic-form/form-fields/MarkdownField";
 import { NumberFormField } from "@/core-features/dynamic-form/form-fields/NumberField";
-import { dateTimeToString, dateTimeToStringPrecision, dateToString, stringToDate, stringToDateTime, stringToTime, timeToString, timeToStringPrecision } from "@/core-features/dynamic-form/value-convertor";
+import {
+  dateTimeToString,
+  dateTimeToStringPrecision,
+  dateToString,
+  stringToDate,
+  stringToDateTime,
+  stringToTime,
+  timeToString,
+  timeToStringPrecision,
+} from "@/core-features/dynamic-form/value-convertor";
 import { DateTimeFormField } from "@/core-features/dynamic-form/form-fields/DateTimeField";
 import { TimeFormField } from "@/core-features/dynamic-form/form-fields/TimeField";
 import { DateFormField } from "@/core-features/dynamic-form/form-fields/DateField";
@@ -14,699 +29,853 @@ import { BooleanSelectFormField } from "@/core-features/dynamic-form/form-fields
 import { JSONFormField } from "@/core-features/dynamic-form/form-fields/JSONField";
 import { SingleChoiceFormField } from "@/core-features/dynamic-form/form-fields/SingleChoice";
 import dayjs, { Dayjs } from "dayjs";
-import { LookupManyFIELDFormField, OptionTag as OptionTagMany } from "@/core-features/dynamic-form/form-fields/LookupManyFIELD";
-import { LookupOneFIELDFormField, OptionTag as OptionTagOne } from "@/core-features/dynamic-form/form-fields/LookupOneFIELD";
+import {
+  LookupManyFIELDFormField,
+  OptionTag as OptionTagMany,
+} from "@/core-features/dynamic-form/form-fields/LookupManyFIELD";
+import {
+  LookupOneFIELDFormField,
+  OptionTag as OptionTagOne,
+} from "@/core-features/dynamic-form/form-fields/LookupOneFIELD";
 import { Options, Option } from "@/core-features/dynamic-form/form-field";
 import { MultipleChoiceFormField } from "@/core-features/dynamic-form/form-fields/MultipleChoice";
 import { isJsonOrNull, toJsonOrNull } from "@/lib/utils/is-json";
 
 type FieldDetails = {
-	schema: z.ZodTypeAny;
-	input: ReactNode;
-	convertFromRawValue?: (value: any) => any;
-}
+  schema: z.ZodTypeAny;
+  input: ReactNode;
+  convertFromRawValue?: (value: any) => any;
+};
 
 const getShortText = (field: Field): FieldDetails => {
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z.string().optional().nullish();
+  })();
 
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? '',
-				z.string().min(1, `${field.caption} is required`)
-			);
-		}
-		return z.string().optional().nullish();
-	})();
-
-	return {
-		schema,
-		input: <TextShortFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} />
-	}
-}
+  return {
+    schema,
+    input: (
+      <TextShortFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
 const getLongText = (field: Field): FieldDetails => {
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z.string().optional().nullish();
+  })();
 
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? '',
-				z.string().min(1, `${field.caption} is required`)
-			);
-		}
-		return z.string().optional().nullish();
-	})();
-
-	return {
-		schema,
-		input: <TextLongFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} />
-	}
-}
-
+  return {
+    schema,
+    input: (
+      <TextLongFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
 const getRichText = (field: Field): FieldDetails => {
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z.string().optional().nullish();
+  })();
 
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? '',
-				z.string().min(1, `${field.caption} is required`)
-			);
-		}
-		return z.string().optional().nullish();
-	})();
+  return {
+    schema,
+    input: (
+      <RichTextFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
-	return {
-		schema,
-		input: <RichTextFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} />
-	}
-}
+const getMarkdown = (field: Field): FieldDetails => {
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z.string().optional().nullish();
+  })();
+
+  return {
+    schema,
+    input: (
+      <MarkdownFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
 const getEmail = (field: Field): FieldDetails => {
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(
-				(val) => (typeof val === "string" ? val.trim() : val),
-				z.string().min(1, `${field.caption} is required`).email('Invalid Email')
-			);
-		}
-		return z.preprocess(
-			(val) => (typeof val === "string" && val.trim() === "" ? undefined : val),
-			z.string().email("Invalid Email").optional().nullish()
-		);
-	})();
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (val) => (typeof val === "string" ? val.trim() : val),
+        z
+          .string()
+          .min(1, `${field.caption} is required`)
+          .email("Invalid Email"),
+      );
+    }
+    return z.preprocess(
+      (val) => (typeof val === "string" && val.trim() === "" ? undefined : val),
+      z.string().email("Invalid Email").optional().nullish(),
+    );
+  })();
 
-	return {
-		schema,
-		input: <TextShortFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} />
-	}
-}
+  return {
+    schema,
+    input: (
+      <TextShortFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
 const getNumber = (field: Field): FieldDetails => {
+  // 1) Normalize empty → null, otherwise pass through to z.coerce.number()
+  let schema: z.ZodTypeAny = z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    return value;
+  }, z.coerce.number().nullable());
 
-	// 1) Normalize empty → null, otherwise pass through to z.coerce.number()
-	let schema: z.ZodTypeAny = z.preprocess((value) => {
-		if (value === null || value === undefined || value === "") {
-			return null;
-		}
-		return value;
-	}, z.coerce.number().nullable());
+  // 2) If required, disallow null
+  if (field.required) {
+    schema = schema.refine((val) => val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
-	// 2) If required, disallow null
-	if (field.required) {
-		schema = schema.refine((val) => val !== null, {
-			message: `${field.caption} is required`,
-		});
-	}
+  // Helper: only run test when there _is_ a number
+  const isNullOr = (fn: (n: number) => boolean) => (val: number | null) =>
+    val === null || fn(val);
 
-	// Helper: only run test when there _is_ a number
-	const isNullOr = (fn: (n: number) => boolean) =>
-		(val: number | null) => val === null || fn(val);
+  // 3) Min check (if configured)
+  if (field.min != null) {
+    const minVal = +field.min;
+    schema = schema.refine(
+      isNullOr((n) => n >= minVal),
+      { message: `${field.caption} must be ≥ ${minVal}` },
+    );
+  }
 
-	// 3) Min check (if configured)
-	if (field.min != null) {
-		const minVal = +field.min;
-		schema = schema.refine(
-			isNullOr((n) => n >= minVal),
-			{ message: `${field.caption} must be ≥ ${minVal}` }
-		);
-	}
+  // 4) Max check (if configured)
+  if (field.max != null) {
+    const maxVal = +field.max;
+    schema = schema.refine(
+      isNullOr((n) => n <= maxVal),
+      { message: `${field.caption} must be ≤ ${maxVal}` },
+    );
+  }
 
-	// 4) Max check (if configured)
-	if (field.max != null) {
-		const maxVal = +field.max;
-		schema = schema.refine(
-			isNullOr((n) => n <= maxVal),
-			{ message: `${field.caption} must be ≤ ${maxVal}` }
-		);
-	}
-
-
-	return {
-		schema,
-		input: <NumberFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} min={field.min ?? undefined} max={field.max ?? undefined} />
-	}
-}
-
+  return {
+    schema,
+    input: (
+      <NumberFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+        min={field.min ?? undefined}
+        max={field.max ?? undefined}
+      />
+    ),
+  };
+};
 
 const getDateTime = (field: Field): FieldDetails => {
+  // 1. Preprocess empty → null; strings → Dayjs
+  let schema: z.ZodTypeAny = z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    if (typeof value === "string") {
+      // try to parse
+      const dt = stringToDateTime(value);
+      return dt ?? value;
+    }
+    return value;
+  }, z.any().nullable());
 
-	// 1. Preprocess empty → null; strings → Dayjs
-	let schema: z.ZodTypeAny = z.preprocess((value) => {
-		if (value === null || value === undefined || value === "") {
-			return null;
-		}
-		if (typeof value === "string") {
-			// try to parse
-			const dt = stringToDateTime(value);
-			return dt ?? value;
-		}
-		return value;
-	}, z.any().nullable());
+  // 2. “Required?” check
+  if (field.required) {
+    schema = schema.refine((val) => val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
-	// 2. “Required?” check
-	if (field.required) {
-		schema = schema.refine((val) => val !== null, {
-			message: `${field.caption} is required`,
-		});
-	}
+  // Helper: only run a test if there’s actually a date
+  const isNullOr = (fn: (d: Dayjs) => boolean) => (val: Dayjs | null) =>
+    val === null || fn(val);
 
-	// Helper: only run a test if there’s actually a date
-	const isNullOr = (fn: (d: Dayjs) => boolean) =>
-		(val: Dayjs | null) => val === null || fn(val);
+  let min: Dayjs | undefined = undefined;
+  let max: Dayjs | undefined = undefined;
 
-	let min: Dayjs | undefined = undefined;
-	let max: Dayjs | undefined = undefined;
+  // 3. Min-date check
+  if (field.min) {
+    min = stringToDateTime(field.min)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isBefore(min)),
+      { message: `${field.caption} must be ≥ ${field.min}` },
+    );
+  }
 
-	// 3. Min-date check
-	if (field.min) {
-		min = stringToDateTime(field.min)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isBefore(min)),
-			{ message: `${field.caption} must be ≥ ${field.min}` }
-		);
-	}
+  // 4. Max-date check
+  if (field.max) {
+    max = stringToDateTime(field.max)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isAfter(max)),
+      { message: `${field.caption} must be ≤ ${field.max}` },
+    );
+  }
 
-	// 4. Max-date check
-	if (field.max) {
-		max = stringToDateTime(field.max)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isAfter(max)),
-			{ message: `${field.caption} must be ≤ ${field.max}` }
-		);
-	}
+  schema = schema.transform((val) => dateTimeToStringPrecision(val));
 
-	schema = schema.transform((val) => dateTimeToStringPrecision(val));
-
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? stringToDateTime(field.defaultValue) : undefined,
-		convertFromRawValue: (value) => {
-			return value ? stringToDateTime(value) : undefined;
-		},
-		input: <DateTimeFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} min={min} max={max} />
-	}
-}
-
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? stringToDateTime(field.defaultValue) : undefined,
+    convertFromRawValue: (value) => {
+      return value ? stringToDateTime(value) : undefined;
+    },
+    input: (
+      <DateTimeFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+        min={min}
+        max={max}
+      />
+    ),
+  };
+};
 
 const getDate = (field: Field): FieldDetails => {
-	// 1. Preprocess empty → null; strings → Dayjs
-	let schema: z.ZodTypeAny = z.preprocess((value) => {
-		if (value === null || value === undefined || value === "") {
-			return null;
-		}
-		if (typeof value === "string") {
-			// try to parse
-			const dt = stringToDate(value);
-			return dt ?? value;
-		}
-		return value;
-	}, z.any().nullable());
+  // 1. Preprocess empty → null; strings → Dayjs
+  let schema: z.ZodTypeAny = z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    if (typeof value === "string") {
+      // try to parse
+      const dt = stringToDate(value);
+      return dt ?? value;
+    }
+    return value;
+  }, z.any().nullable());
 
-	// 2. “Required?” check
-	if (field.required) {
-		schema = schema.refine((val) => val !== null, {
-			message: `${field.caption} is required`,
-		});
-	}
+  // 2. “Required?” check
+  if (field.required) {
+    schema = schema.refine((val) => val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
-	// Helper: only run a test if there’s actually a date
-	const isNullOr = (fn: (d: Dayjs) => boolean) =>
-		(val: Dayjs | null) => val === null || fn(val);
+  // Helper: only run a test if there’s actually a date
+  const isNullOr = (fn: (d: Dayjs) => boolean) => (val: Dayjs | null) =>
+    val === null || fn(val);
 
-	let min: Dayjs | undefined = undefined;
-	let max: Dayjs | undefined = undefined;
+  let min: Dayjs | undefined = undefined;
+  let max: Dayjs | undefined = undefined;
 
-	// 3. Min-date check
-	if (field.min) {
-		min = stringToDate(field.min)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isBefore(min)),
-			{ message: `${field.caption} must be ≥ ${field.min}` }
-		);
-	}
+  // 3. Min-date check
+  if (field.min) {
+    min = stringToDate(field.min)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isBefore(min)),
+      { message: `${field.caption} must be ≥ ${field.min}` },
+    );
+  }
 
-	// 4. Max-date check
-	if (field.max) {
-		max = stringToDate(field.max)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isAfter(max)),
-			{ message: `${field.caption} must be ≤ ${field.max}` }
-		);
-	}
+  // 4. Max-date check
+  if (field.max) {
+    max = stringToDate(field.max)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isAfter(max)),
+      { message: `${field.caption} must be ≤ ${field.max}` },
+    );
+  }
 
-	schema = schema.transform((val) => dateToString(val));
+  schema = schema.transform((val) => dateToString(val));
 
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? stringToDate(field.defaultValue) : undefined,
-		convertFromRawValue: (value) => {
-			return value ? stringToDate(value) : undefined;
-		},
-		input: <DateFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} min={min} max={max} />
-	}
-}
-
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? stringToDate(field.defaultValue) : undefined,
+    convertFromRawValue: (value) => {
+      return value ? stringToDate(value) : undefined;
+    },
+    input: (
+      <DateFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+        min={min}
+        max={max}
+      />
+    ),
+  };
+};
 
 const getTime = (field: Field): FieldDetails => {
-	// 1. Preprocess empty → null; strings → Dayjs
-	let schema: z.ZodTypeAny = z.preprocess((value) => {
-		if (value === null || value === undefined || value === "") {
-			return null;
-		}
-		if (typeof value === "string") {
-			// try to parse
-			const dt = stringToTime(value);
-			return dt ?? value;
-		}
-		return value;
-	}, z.any().nullable());
+  // 1. Preprocess empty → null; strings → Dayjs
+  let schema: z.ZodTypeAny = z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    if (typeof value === "string") {
+      // try to parse
+      const dt = stringToTime(value);
+      return dt ?? value;
+    }
+    return value;
+  }, z.any().nullable());
 
-	// 2. “Required?” check
-	if (field.required) {
-		schema = schema.refine((val) => val !== null, {
-			message: `${field.caption} is required`,
-		});
-	}
+  // 2. “Required?” check
+  if (field.required) {
+    schema = schema.refine((val) => val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
-	// Helper: only run a test if there’s actually a date
-	const isNullOr = (fn: (d: Dayjs) => boolean) =>
-		(val: Dayjs | null) => val === null || fn(val);
+  // Helper: only run a test if there’s actually a date
+  const isNullOr = (fn: (d: Dayjs) => boolean) => (val: Dayjs | null) =>
+    val === null || fn(val);
 
-	let min: Dayjs | undefined = undefined;
-	let max: Dayjs | undefined = undefined;
+  let min: Dayjs | undefined = undefined;
+  let max: Dayjs | undefined = undefined;
 
-	// 3. Min-date check
-	if (field.min) {
-		min = stringToTime(field.min)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isBefore(min)),
-			{ message: `${field.caption} must be ≥ ${field.min}` }
-		);
-	}
+  // 3. Min-date check
+  if (field.min) {
+    min = stringToTime(field.min)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isBefore(min)),
+      { message: `${field.caption} must be ≥ ${field.min}` },
+    );
+  }
 
-	// 4. Max-date check
-	if (field.max) {
-		max = stringToTime(field.max)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isAfter(max)),
-			{ message: `${field.caption} must be ≤ ${field.max}` }
-		);
-	}
+  // 4. Max-date check
+  if (field.max) {
+    max = stringToTime(field.max)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isAfter(max)),
+      { message: `${field.caption} must be ≤ ${field.max}` },
+    );
+  }
 
-	schema = schema.transform((val) => timeToStringPrecision(val));
+  schema = schema.transform((val) => timeToStringPrecision(val));
 
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? stringToTime(field.defaultValue) : undefined,
-		convertFromRawValue: (value) => {
-			return value ? stringToTime(value) : undefined;
-		},
-		input: <TimeFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} min={min} max={max} />
-	}
-}
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? stringToTime(field.defaultValue) : undefined,
+    convertFromRawValue: (value) => {
+      return value ? stringToTime(value) : undefined;
+    },
+    input: (
+      <TimeFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+        min={min}
+        max={max}
+      />
+    ),
+  };
+};
 
 const getBoolean = (field: Field): FieldDetails => {
-	const baseSchema = z.boolean();
+  const baseSchema = z.boolean();
 
-	let schema;
-	if (field.required) {
-		schema = baseSchema.refine(
-			(data) => data !== undefined,
-			{ message: `${field.caption} is required` }
-		);
-	} else {
-		schema = baseSchema.optional();
-	}
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? !!field.defaultValue : undefined,
-		convertFromRawValue: (value) => {
-			return value ? !!value : undefined;
-		},
-		input: <BooleanSelectFormField key={field.name} name={field.name} label={field.caption} />
-	}
-}
-
+  let schema;
+  if (field.required) {
+    schema = baseSchema.refine((data) => data !== undefined, {
+      message: `${field.caption} is required`,
+    });
+  } else {
+    schema = baseSchema.optional();
+  }
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? !!field.defaultValue : undefined,
+    convertFromRawValue: (value) => {
+      return value ? !!value : undefined;
+    },
+    input: (
+      <BooleanSelectFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+      />
+    ),
+  };
+};
 
 const getJson = (field: Field): FieldDetails => {
+  let schema: z.ZodTypeAny = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z
+      .string()
+      .transform((i) => i?.trim() || undefined)
+      .optional()
+      .nullish();
+  })();
 
-	let schema: z.ZodTypeAny = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? '',
-				z.string().min(1, `${field.caption} is required`)
-			);
-		}
-		return z.string().transform((i) => i?.trim() || undefined).optional().nullish();
-	})();
+  // 2) If required, ban empty/null
+  if (field.required) {
+    schema = schema.refine((val) => val !== undefined && val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
+  // 3) JSON‐validity only if there is a value
+  schema = schema
+    .refine((val) => val === undefined || val === null || isJsonOrNull(val), {
+      message: `${field.caption} must be valid JSON`,
+    })
+    .transform((val) => (toJsonOrNull(val) ? JSON.parse(val) : undefined));
 
-	// 2) If required, ban empty/null
-	if (field.required) {
-		schema = schema.refine(
-			(val) => val !== undefined && val !== null,
-			{ message: `${field.caption} is required` }
-		);
-	}
-
-	// 3) JSON‐validity only if there is a value
-	schema = schema.refine(
-		(val) => val === undefined || val === null || isJsonOrNull(val),
-		{ message: `${field.caption} must be valid JSON` }
-	).transform((val) => toJsonOrNull(val) ? JSON.parse(val) : undefined);
-
-	return {
-		schema,
-		convertFromRawValue: (value) => {
-			if (typeof value === 'string') {
-				return value;
-			}
-			return value ? JSON.stringify(value) : undefined;
-		},
-		input: <JSONFormField key={field.name} name={field.name} label={field.caption} />
-	}
-}
+  return {
+    schema,
+    convertFromRawValue: (value) => {
+      if (typeof value === "string") {
+        return value;
+      }
+      return value ? JSON.stringify(value) : undefined;
+    },
+    input: (
+      <JSONFormField key={field.name} name={field.name} label={field.caption} />
+    ),
+  };
+};
 
 const getSingleChoice = (field: Field): FieldDetails => {
+  let schema = field.required
+    ? z
+        .any()
+        .refine((val) => !!val, { message: `${field.caption} is required` })
+    : z.string().optional().nullable();
 
-	let schema = field.required
-		? z.any().refine((val) => !!val, { message: `${field.caption} is required` })
-		: z.string().optional().nullable();
+  const options =
+    field.acceptedValues
+      ?.filter((i) => i)
+      .map((i: string | null) => ({
+        label: i!,
+        value: i!,
+      })) ?? [];
 
-	const options = field.acceptedValues?.filter(i => i)
-		.map((i: string | null) => ({
-			label: i!,
-			value: i!
-		})) ?? [];
-
-	return {
-		schema,
-		input: <SingleChoiceFormField key={field.name} name={field.name} label={field.caption} options={options} />
-	}
-}
-
+  return {
+    schema,
+    input: (
+      <SingleChoiceFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        options={options}
+      />
+    ),
+  };
+};
 
 const getMultiChoice = (field: Field): FieldDetails => {
+  // let schema = field.required
+  //     ? z.any().refine((val) => !!val && val.length, { message: `${field.caption} is required` })
+  //     : z.string().optional().nullable();
 
-	// let schema = field.required
-	//     ? z.any().refine((val) => !!val && val.length, { message: `${field.caption} is required` })
-	//     : z.string().optional().nullable();
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? [],
+        z.array(z.string()).min(1, `${field.caption} is required`),
+      );
+    }
+    return z.array(z.string()).optional().nullish();
+  })();
 
+  const options =
+    field.acceptedValues
+      ?.filter((i) => i)
+      .map((i: string | null) => ({
+        label: i!,
+        value: i!,
+      })) ?? [];
 
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? [],
-				z.array(z.string()).min(1, `${field.caption} is required`)
-			);
-		}
-		return z.array(z.string()).optional().nullish();
-	})();
-
-	const options = field.acceptedValues?.filter(i => i)
-		.map((i: string | null) => ({
-			label: i!,
-			value: i!
-		})) ?? [];
-
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? JSON.parse(field.defaultValue) : undefined,
-		convertFromRawValue: (value) => {
-			if (Array.isArray(value)) {
-				return value;
-			}
-			return value ? JSON.parse(value) : undefined;
-		},
-		input: <MultipleChoiceFormField key={field.name} name={field.name} label={field.caption} options={options} />
-	}
-}
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? JSON.parse(field.defaultValue) : undefined,
+    convertFromRawValue: (value) => {
+      if (Array.isArray(value)) {
+        return value;
+      }
+      return value ? JSON.parse(value) : undefined;
+    },
+    input: (
+      <MultipleChoiceFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        options={options}
+      />
+    ),
+  };
+};
 
 const getRelationOne = (entityName: string, edge: Edge): FieldDetails => {
+  let schema: z.ZodTypeAny = edge.required
+    ? z.any().refine((val): val is Record<string, unknown> => !val, {
+        message: `${edge.caption} is required`,
+      })
+    : z.any().optional().nullable();
 
-	let schema: z.ZodTypeAny = edge.required
-		? z.any().refine((val): val is Record<string, unknown> => !val,
-			{ message: `${edge.caption} is required` }
-		)
-		: z.any().optional().nullable();
+  schema = schema.transform((val?: Option<string, OptionTagOne>) => {
+    if (!val) {
+      return undefined;
+    }
 
-	schema = schema.transform((val?: Option<string, OptionTagOne>) => {
+    if (!val.tag) {
+      return undefined;
+    }
 
-		if (!val) {
-			return undefined;
-		}
+    switch (val.tag) {
+      case "create":
+        return {
+          create: val.value,
+        };
+      case "connect":
+        return {
+          connect: {
+            id: val.value,
+          },
+        };
+      case "unset":
+        return {
+          unset: true,
+        };
+    }
+  });
 
-		if (!val.tag) {
-			return undefined;
-		}
-
-		switch (val.tag) {
-			case 'create':
-				return {
-					create: val.value
-				}
-			case 'connect':
-				return {
-					connect: {
-						id: val.value
-					}
-				}
-			case 'unset':
-				return {
-					unset: true
-				}
-		}
-
-	});
-
-	return {
-		schema,
-		convertFromRawValue: (val) => undefined,
-		input: <LookupOneFIELDFormField key={edge.name} name={edge.name} label={edge.caption} entityName={entityName} edge={edge} />
-	}
-}
+  return {
+    schema,
+    convertFromRawValue: (val) => undefined,
+    input: (
+      <LookupOneFIELDFormField
+        key={edge.name}
+        name={edge.name}
+        label={edge.caption}
+        entityName={entityName}
+        edge={edge}
+      />
+    ),
+  };
+};
 
 const getRelationMany = (entityName: string, edge: Edge): FieldDetails => {
-	let schema: z.ZodTypeAny = edge.required
-		? z.any().refine((val): val is Record<string, unknown> => !val,
-			{ message: `${edge.caption} is required` }
-		)
-		: z.any().optional().nullable();
+  let schema: z.ZodTypeAny = edge.required
+    ? z.any().refine((val): val is Record<string, unknown> => !val, {
+        message: `${edge.caption} is required`,
+      })
+    : z.any().optional().nullable();
 
-	schema = schema.transform((val?: Options<string, OptionTagMany>) => {
+  schema = schema.transform((val?: Options<string, OptionTagMany>) => {
+    if (!val) {
+      return undefined;
+    }
 
-		if (!val) {
-			return undefined;
-		}
+    return {
+      connect: val
+        .filter((i) => i.tag == "connect")
+        .map((i) => ({
+          id: i.value,
+        })),
+      create: val.filter((i) => i.tag == "create").map((i) => i.value),
+      disconnect: val
+        .filter((i) => i.tag == "disconnect")
+        .map((i) => ({
+          id: i.value,
+        })),
+    };
+  });
 
-		return {
-			connect: val.filter(i => i.tag == 'connect')
-				.map(i => ({
-					id: i.value
-				})),
-			create: val.filter(i => i.tag == 'create')
-				.map(i => i.value),
-			disconnect: val.filter(i => i.tag == 'disconnect')
-				.map(i => ({
-					id: i.value
-				}))
-		}
-	});
-
-	return {
-		schema,
-		convertFromRawValue: (val) => undefined,
-		input: <LookupManyFIELDFormField key={edge.name} name={edge.name} label={edge.caption} entityName={entityName} edge={edge} />
-	}
-}
+  return {
+    schema,
+    convertFromRawValue: (val) => undefined,
+    input: (
+      <LookupManyFIELDFormField
+        key={edge.name}
+        name={edge.name}
+        label={edge.caption}
+        entityName={entityName}
+        edge={edge}
+      />
+    ),
+  };
+};
 
 const getFormField = (field: Field): FieldDetails => {
-	switch (field.type) {
-		case "ShortText": return getShortText(field);
-		case "LongText": return getLongText(field);
-		case "RichText": return getRichText(field);
-		case "Email": return getEmail(field);
-		case "Integer": return getNumber(field);
-		case "Decimal": return getNumber(field);
-		case "Float": return getNumber(field);
-		case "DateTime": return getDateTime(field);
-		case "Date": return getDate(field);
-		case "Time": return getTime(field);
-		case "Media": return getShortText(field);
-		case "Boolean": return getBoolean(field);
-		case "Json": return getJson(field);
-		case "SingleChoice": return getSingleChoice(field);
-		case "MultipleChoice": return getMultiChoice(field);
-		default: return getShortText(field);
-	}
-}
+  switch (field.type) {
+    case "ShortText":
+      return getShortText(field);
+    case "LongText":
+      return getLongText(field);
+    case "RichText":
+      return getRichText(field);
+    case "Markdown":
+      return getMarkdown(field);
+    case "Email":
+      return getEmail(field);
+    case "Integer":
+      return getNumber(field);
+    case "Decimal":
+      return getNumber(field);
+    case "Float":
+      return getNumber(field);
+    case "DateTime":
+      return getDateTime(field);
+    case "Date":
+      return getDate(field);
+    case "Time":
+      return getTime(field);
+    case "Media":
+      return getShortText(field);
+    case "Boolean":
+      return getBoolean(field);
+    case "Json":
+      return getJson(field);
+    case "SingleChoice":
+      return getSingleChoice(field);
+    case "MultipleChoice":
+      return getMultiChoice(field);
+    default:
+      return getShortText(field);
+  }
+};
 
 const getFormEdge = (entityName: string, edge: Edge): FieldDetails => {
-	switch (edge.relationType) {
-		case RelationType.One:
-		case RelationType.OneToOne:
-		case RelationType.OneToMany:
-			return getRelationOne(entityName, edge);
+  switch (edge.relationType) {
+    case RelationType.One:
+    case RelationType.OneToOne:
+    case RelationType.OneToMany:
+      return getRelationOne(entityName, edge);
 
-		case RelationType.Many:
-		case RelationType.ManyToOne:
-		case RelationType.ManyToMany:
-			return getRelationMany(entityName, edge);
+    case RelationType.Many:
+    case RelationType.ManyToOne:
+    case RelationType.ManyToMany:
+      return getRelationMany(entityName, edge);
 
-		default:
-			return {
-				schema: z.any().nullable(),
-				input: <>Unknown Relation</>
-			}
-	}
-
-}
-
+    default:
+      return {
+        schema: z.any().nullable(),
+        input: <>Unknown Relation</>,
+      };
+  }
+};
 
 export const useContentManagerFormSchema = (entity: FullEntity | null) => {
+  const fieldsDescriptors = useMemo(() => {
+    if (!entity) {
+      return [];
+    }
 
-	const fieldsDescriptors = useMemo(() => {
-		if (!entity) {
-			return [];
-		}
+    const fields = entity
+      .fields!.filter((i) => i.name != "id") // skip id
+      .filter((i) => i.name != "createdAt" && i.name != "updatedAt") // TODO: skip createdAt, updateAt from form schema
+      .map((field) => ({
+        ...getFormField(field),
+        name: field.name,
+        field,
+      }));
 
-		const fields = entity.fields!
-			.filter(i => i.name != 'id') // skip id
-			.filter(i => i.name != 'createdAt' && i.name != 'updatedAt') // TODO: skip createdAt, updateAt from form schema
-			.map((field) => ({
-				...getFormField(field),
-				name: field.name,
-				field
-			}));
+    const edges = entity
+      .edges!.filter((i) => i.name.startsWith("ref") == false) //TODO: ref fields will be removed from BE
+      .filter((i) => i.name != "createdBy" && i.name != "updatedBy") // skip createdBy, updatedBy from form schema
+      .map((edge) => ({
+        ...getFormEdge(entity.name, edge),
+        name: edge.name,
+        edge,
+      }));
 
-		const edges = entity.edges!
-			.filter(i => i.name.startsWith('ref') == false) //TODO: ref fields will be removed from BE
-			.filter(i => i.name != 'createdBy' && i.name != 'updatedBy') // skip createdBy, updatedBy from form schema
-			.map((edge) => ({
-				...getFormEdge(entity.name, edge),
-				name: edge.name,
-				edge
-			}));
+    return [...fields, ...edges];
+  }, [entity]);
 
-		return [
-			...fields,
-			...edges
-		]
+  const schema = useMemo(() => {
+    const fieldsSchema = fieldsDescriptors.reduce(
+      (acc: any, field) => {
+        acc = {
+          ...acc,
+          [field.name]: field.schema,
+        };
+        return acc;
+      },
+      {} as Record<string, z.ZodTypeAny>,
+    );
 
-	}, [entity]);
+    return z.object(fieldsSchema);
+  }, [fieldsDescriptors]);
 
-	const schema = useMemo(() => {
-		const fieldsSchema = fieldsDescriptors.reduce((acc: any, field) => {
-			acc = {
-				...acc,
-				[field.name]: field.schema
-			}
-			return acc;
-		}, {} as Record<string, z.ZodTypeAny>);
+  const fields = useMemo(() => {
+    return fieldsDescriptors.map((field) => field.input);
+  }, [fieldsDescriptors]);
 
-		return z.object(fieldsSchema);
-	}, [fieldsDescriptors]);
+  const schemaDefaultValue = useMemo(() => {
+    return entity?.fields.reduce((acc: any, field) => {
+      if (field.defaultValue) {
+        acc[field.name] = field.defaultValue;
+      }
+      return acc;
+    }, {});
+  }, [entity?.fields]);
 
-	const fields = useMemo(() => {
-		return fieldsDescriptors.map(field => field.input);
-	}, [fieldsDescriptors]);
+  const convertFromRawValue = useCallback((defaultValue: any) => {
+    if (!defaultValue) {
+      return defaultValue;
+    }
 
-	const schemaDefaultValue = useMemo(() => {
-		return entity?.fields.reduce((acc: any, field) => {
-			if (field.defaultValue) {
-				acc[field.name] = field.defaultValue;
-			}
-			return acc;
-		}, {});
-	}, [entity?.fields]);
+    const keys = Object.keys(defaultValue);
+    const result = keys.reduce((acc: any, key) => {
+      const feldDescription = fieldsDescriptors.find((i) => i.name == key);
+      const value = feldDescription?.convertFromRawValue
+        ? feldDescription?.convertFromRawValue?.(defaultValue[key])
+        : defaultValue[key];
 
-	const convertFromRawValue = useCallback((defaultValue: any) => {
-		if (!defaultValue) {
-			return defaultValue;
-		}
+      if (value == undefined || value == null) {
+        return acc;
+      }
 
-		const keys = Object.keys(defaultValue);
-		const result = keys.reduce((acc: any, key) => {
-			const feldDescription = fieldsDescriptors.find(i => i.name == key);
-			const value = feldDescription?.convertFromRawValue ? feldDescription?.convertFromRawValue?.(defaultValue[key]) : defaultValue[key];
+      acc[key] = value;
+      return acc;
+    }, {});
 
-			if (value == undefined || value == null) {
-				return acc;
-			}
+    return result;
+  }, []);
 
-			acc[key] = value;
-			return acc;
-		}, {});
+  return useMemo(
+    () => ({
+      schema,
+      fields,
+      schemaDefaultValue,
+      convertFromRawValue,
+    }),
+    [schema, fields],
+  );
+};
 
-		return result;
-	}, []);
+useContentManagerFormSchema.displayName = "useContentManagerFormSchema";
 
-	return useMemo(() => ({
-		schema,
-		fields,
-		schemaDefaultValue,
-		convertFromRawValue
-	}), [schema, fields]);
-}
+export const useGenericFiedFormSchema = () => {};
 
-useContentManagerFormSchema.displayName = 'useContentManagerFormSchema';
+export const useGenericEdgeFormSchema = (
+  entity: FullEntity | null,
+  edgeName: string,
+) => {
+  const edge = useMemo(() => {
+    if (!entity) {
+      return null;
+    }
+    return entity.edges?.find((i) => i.name === edgeName);
+  }, [entity, edgeName]);
 
+  const edgeDescriptor = useMemo(() => {
+    if (!entity) {
+      return null;
+    }
 
-export const useGenericFiedFormSchema = () => {
+    if (!edge) {
+      return null;
+    }
 
-}
+    const result = {
+      ...getFormEdge(entity.name, edge),
+      name: edge.name,
+      edge,
+    };
+    return result;
+  }, [entity, edge]);
 
-export const useGenericEdgeFormSchema = (entity: FullEntity | null, edgeName: string) => {
+  const convertFromRawValue = useCallback(
+    (defaultValue: any) => {
+      if (!edge) {
+        return null;
+      }
 
-	const edge = useMemo(() => {
-		if (!entity) {
-			return null;
-		}
-		return entity.edges?.find(i => i.name === edgeName);
-	}, [entity, edgeName]);
+      const value = edgeDescriptor?.convertFromRawValue
+        ? edgeDescriptor?.convertFromRawValue?.(defaultValue)
+        : defaultValue;
+      return value;
+    },
+    [edgeDescriptor, edge],
+  );
 
-	const edgeDescriptor = useMemo(() => {
-		if (!entity) {
-			return null;
-		}
+  const field = useMemo((): ReactNode => {
+    if (!edgeDescriptor) {
+      return <></>;
+    }
 
-		if (!edge) {
-			return null;
-		}
+    return edgeDescriptor.input;
+  }, [edgeDescriptor]);
 
-		const result = {
-			...getFormEdge(entity.name, edge),
-			name: edge.name,
-			edge
-		};
-		return result;
-	}, [entity, edge]);
+  const schema = useMemo(() => {
+    if (!edgeDescriptor) {
+      return z.any();
+    }
 
-	const convertFromRawValue = useCallback((defaultValue: any) => {
+    return edgeDescriptor.schema;
+  }, [edgeDescriptor]);
 
-		if (!edge) {
-			return null;
-		}
-
-		const value = edgeDescriptor?.convertFromRawValue ? edgeDescriptor?.convertFromRawValue?.(defaultValue) : defaultValue;
-		return value;
-	}, [edgeDescriptor, edge]);
-
-	const field = useMemo(():ReactNode => {
-		if (!edgeDescriptor) {
-			return <></>;
-		}
-
-		return edgeDescriptor.input;
-	}, [edgeDescriptor]);
-
-	const schema = useMemo(() => {
-		if (!edgeDescriptor) {
-			return z.any();
-		}
-
-		return edgeDescriptor.schema;
-	}, [edgeDescriptor]);
-
-	return useMemo(() => ({
-		edgeDescriptor,
-		convertFromRawValue,
-		field,
-		schema
-	}), [edgeDescriptor, convertFromRawValue, field, schema]);
-}
+  return useMemo(
+    () => ({
+      edgeDescriptor,
+      convertFromRawValue,
+      field,
+      schema,
+    }),
+    [edgeDescriptor, convertFromRawValue, field, schema],
+  );
+};

--- a/src/admin/src/features/content-manager/use-dyamic-grid-filter.tsx
+++ b/src/admin/src/features/content-manager/use-dyamic-grid-filter.tsx
@@ -1,127 +1,177 @@
-import { containsFoldOperator, lessThanOrEqualDateTimeOperator, lessThanOrEqualNumberOperator } from "@/core-features/dynamic-filter/filter-operators";
-import { Field } from "@/lib/apollo/graphql.entities"
+import {
+  containsFoldOperator,
+  lessThanOrEqualDateTimeOperator,
+  lessThanOrEqualNumberOperator,
+} from "@/core-features/dynamic-filter/filter-operators";
+import { Field } from "@/lib/apollo/graphql.entities";
 import { ApiFieldTypes, FormFieldTypes } from "@/types/field-type-descriptor";
 import { ColumnDefFilter } from "mosaic-data-table";
 import { useMemo } from "react";
 
 interface UseDynamicGridFilterProps {
-    fields?: Field[],
+  fields?: Field[];
 }
-export const useDyamicGridFilter = (props: UseDynamicGridFilterProps): Record<string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">> => {
-
-    return useMemo(() => {
-
-        if(!props.fields){
-            return {}
-        }
-
-        return props.fields?.reduce((acc: Record<string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">>, field: Field) => {
-            const filterDef = fieldToFilter(field);
-
-            if (!filterDef) {
-                return acc;
-            }
-
-            const [name, filter] = filterDef!;
-
-            if(!filter){
-                return acc;
-            }
-            
-            acc[name] = filter;
-            return acc;
-        }, {});
-
-    }, [props.fields]);
-}
-
-const fieldToFilter = (field: Field): [key: string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">] | null => {
-
-    switch (field.type as ApiFieldTypes) {
-        case 'ShortText':
-        case 'LongText':
-        case 'RichText':
-        case 'Email':
-            return textColumnDef(field.name);
-        case 'Integer': 
-            return numberColumnDef(field.name);
-        case 'DateTime': 
-            return dateTimeColumnDef(field.name);
-        case 'Date': 
-            return dateColumnDef(field.name);
-        case 'Time': 
-            return timeColumnDef(field.name);
-        case 'Boolean': 
-            return booleanColumnDef(field.name);
-        default:
-            return null;
+export const useDyamicGridFilter = (
+  props: UseDynamicGridFilterProps,
+): Record<
+  string,
+  ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">
+> => {
+  return useMemo(() => {
+    if (!props.fields) {
+      return {};
     }
-}
 
+    return props.fields?.reduce(
+      (
+        acc: Record<
+          string,
+          ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">
+        >,
+        field: Field,
+      ) => {
+        const filterDef = fieldToFilter(field);
 
-const textColumnDef = (name: string): [key: string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">] => {
-    return [
-        name,
-        {
-            type: 'string',
-            defaultOperator: containsFoldOperator.name,
+        if (!filterDef) {
+          return acc;
         }
-    ]
-}
 
+        const [name, filter] = filterDef!;
 
-const numberColumnDef = (name: string): [key: string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">] => {
-    return [
-        name,
-        {
-            type: 'number',
-            defaultOperator: lessThanOrEqualNumberOperator.name,
+        if (!filter) {
+          return acc;
         }
-    ]
-}
 
-const dateColumnDef = (name: string): [key: string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">] => {
-    return [
-        name,
-        {
-            type: 'date',
-            defaultOperator: lessThanOrEqualDateTimeOperator.name,
-        }
-    ]
-}
+        acc[name] = filter;
+        return acc;
+      },
+      {},
+    );
+  }, [props.fields]);
+};
 
-const timeColumnDef = (name: string): [key: string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">] => {
-    return [
-        name,
-        {
-            type: 'time',
-            defaultOperator: lessThanOrEqualDateTimeOperator.name,
-        }
-    ]
-}
+const fieldToFilter = (
+  field: Field,
+):
+  | [key: string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">]
+  | null => {
+  switch (field.type as ApiFieldTypes) {
+    case "ShortText":
+    case "LongText":
+    case "RichText":
+    case "Markdown":
+    case "Email":
+      return textColumnDef(field.name);
+    case "Integer":
+      return numberColumnDef(field.name);
+    case "DateTime":
+      return dateTimeColumnDef(field.name);
+    case "Date":
+      return dateColumnDef(field.name);
+    case "Time":
+      return timeColumnDef(field.name);
+    case "Boolean":
+      return booleanColumnDef(field.name);
+    default:
+      return null;
+  }
+};
 
-const dateTimeColumnDef = (name: string): [key: string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">] => {
-    return [
-        name,
-        {
-            type: 'datetime',
-            defaultOperator: lessThanOrEqualDateTimeOperator.name,
-        }
-    ]
-}
+const textColumnDef = (
+  name: string,
+): [
+  key: string,
+  ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">,
+] => {
+  return [
+    name,
+    {
+      type: "string",
+      defaultOperator: containsFoldOperator.name,
+    },
+  ];
+};
 
-const booleanColumnDef = (name: string): [key: string, ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">] => {
-    return [
-        name,
+const numberColumnDef = (
+  name: string,
+): [
+  key: string,
+  ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">,
+] => {
+  return [
+    name,
+    {
+      type: "number",
+      defaultOperator: lessThanOrEqualNumberOperator.name,
+    },
+  ];
+};
+
+const dateColumnDef = (
+  name: string,
+): [
+  key: string,
+  ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">,
+] => {
+  return [
+    name,
+    {
+      type: "date",
+      defaultOperator: lessThanOrEqualDateTimeOperator.name,
+    },
+  ];
+};
+
+const timeColumnDef = (
+  name: string,
+): [
+  key: string,
+  ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">,
+] => {
+  return [
+    name,
+    {
+      type: "time",
+      defaultOperator: lessThanOrEqualDateTimeOperator.name,
+    },
+  ];
+};
+
+const dateTimeColumnDef = (
+  name: string,
+): [
+  key: string,
+  ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">,
+] => {
+  return [
+    name,
+    {
+      type: "datetime",
+      defaultOperator: lessThanOrEqualDateTimeOperator.name,
+    },
+  ];
+};
+
+const booleanColumnDef = (
+  name: string,
+): [
+  key: string,
+  ColumnDefFilter | Exclude<ColumnDefFilter["type"], "select">,
+] => {
+  return [
+    name,
+    {
+      type: "select",
+      selectOptions: [
         {
-            type: 'select',
-			selectOptions: [{
-				label: 'True',
-				value: true
-			}, {
-				label: 'False',
-				value: false
-			}] as any[]
-        }
-    ]
-}
+          label: "True",
+          value: true,
+        },
+        {
+          label: "False",
+          value: false,
+        },
+      ] as any[],
+    },
+  ];
+};

--- a/src/admin/src/features/entity-type-designer/designer-field-map.tsx
+++ b/src/admin/src/features/entity-type-designer/designer-field-map.tsx
@@ -7,7 +7,11 @@ import { PiSpiral } from "react-icons/pi";
 import { TbRelationOneToManyFilled } from "react-icons/tb";
 import { TbRelationOneToOneFilled } from "react-icons/tb";
 import { PiGraphFill } from "react-icons/pi";
-import { ApiFieldTypes, EdgeRelationTypes, FieldScalarTypes } from "@/types/field-type-descriptor";
+import {
+  ApiFieldTypes,
+  EdgeRelationTypes,
+  FieldScalarTypes,
+} from "@/types/field-type-descriptor";
 import { MdShortText } from "react-icons/md";
 import { LuText } from "react-icons/lu";
 import { LuTextQuote } from "react-icons/lu";
@@ -26,39 +30,113 @@ import DocumentIcon from "@/assets/icons/labra/document";
 import { z } from "zod";
 
 import { UseFormReturn } from "react-hook-form";
-import { DesignerForm as shortTextDesignerForm, schema as shortTextSchema, schemaEffect as shortTextSchemaEffect, toDefaultValue as shortTextToDefaultValue } from "./designer-form/short-text-designer";
-import { DesignerForm as longTextDesignerForm, schema as longTextSchema, schemaEffect as longTextSchemaEffect, toDefaultValue as longTextToDefaultValue } from "./designer-form/long-text-designer";
-import { DesignerForm as rtfDesignerForm, schema as rtfSchema, schemaEffect as rtfSchemaEffect, toDefaultValue as rtfToDefaultValue } from "./designer-form/rtf-designer";
-import { DesignerForm as emailDesignerForm, schema as emailSchema, schemaEffect as emailSchemaEffect, toDefaultValue as emailToDefaultValue } from "./designer-form/email-designer";
-import { DesignerForm as numberDesignerForm, schema as numberSchema, schemaEffect as numberSchemaEffect, toDefaultValue as numberToDefaultValue } from "./designer-form/number-designer";
-import { DesignerForm as dateTimeDesignerForm, schema as dateTimeSchema, schemaEffect as dateTimeSchemaEffect, toDefaultValue as dateTimeToDefaultValue } from "./designer-form/date-time-designer";
-import { DesignerForm as dateDesignerForm, schema as dateSchema, schemaEffect as dateSchemaEffect, toDefaultValue as dateToDefaultValue } from "./designer-form/date-designer";
-import { DesignerForm as timeDesignerForm, schema as timeSchema, schemaEffect as timeSchemaEffect, toDefaultValue as timeToDefaultValue } from "./designer-form/time-designer";
-import { DesignerForm as booleanDesignerForm, schema as booleanSchema, schemaEffect as booleanSchemaEffect, toDefaultValue as booleanToDefaultValue } from "./designer-form/boolean-designer";
-import { DesignerForm as jsonDesignerForm, schema as jsonSchema, schemaEffect as jsonSchemaEffect, toDefaultValue as jsonToDefaultValue } from "./designer-form/json-designer";
-import { DesignerForm as singleChoiceDesignerForm, schema as singleChoiceSchema, schemaEffect as singleChoiceSchemaEffect, toDefaultValue as singleChoiceToDefaultValue } from "./designer-form/single-select-designer";
-import { DesignerForm as multipleChoiceDesignerForm, schema as multipleChoiceSchema, schemaEffect as multipleChoiceSchemaEffect, toDefaultValue as multipleChoiceToDefaultValue } from "./designer-form/multiple-select-designer";
-import { DesignerForm as relationDesignerForm, schema as relationSchema, schemaEffect as relationEffect, toDefaultValue as relationToDefaultValue } from "./designer-form/relation-designer";
+import {
+  DesignerForm as shortTextDesignerForm,
+  schema as shortTextSchema,
+  schemaEffect as shortTextSchemaEffect,
+  toDefaultValue as shortTextToDefaultValue,
+} from "./designer-form/short-text-designer";
+import {
+  DesignerForm as longTextDesignerForm,
+  schema as longTextSchema,
+  schemaEffect as longTextSchemaEffect,
+  toDefaultValue as longTextToDefaultValue,
+} from "./designer-form/long-text-designer";
+import {
+  DesignerForm as rtfDesignerForm,
+  schema as rtfSchema,
+  schemaEffect as rtfSchemaEffect,
+  toDefaultValue as rtfToDefaultValue,
+} from "./designer-form/rtf-designer";
+import {
+  DesignerForm as emailDesignerForm,
+  schema as emailSchema,
+  schemaEffect as emailSchemaEffect,
+  toDefaultValue as emailToDefaultValue,
+} from "./designer-form/email-designer";
+import {
+  DesignerForm as numberDesignerForm,
+  schema as numberSchema,
+  schemaEffect as numberSchemaEffect,
+  toDefaultValue as numberToDefaultValue,
+} from "./designer-form/number-designer";
+import {
+  DesignerForm as dateTimeDesignerForm,
+  schema as dateTimeSchema,
+  schemaEffect as dateTimeSchemaEffect,
+  toDefaultValue as dateTimeToDefaultValue,
+} from "./designer-form/date-time-designer";
+import {
+  DesignerForm as dateDesignerForm,
+  schema as dateSchema,
+  schemaEffect as dateSchemaEffect,
+  toDefaultValue as dateToDefaultValue,
+} from "./designer-form/date-designer";
+import {
+  DesignerForm as timeDesignerForm,
+  schema as timeSchema,
+  schemaEffect as timeSchemaEffect,
+  toDefaultValue as timeToDefaultValue,
+} from "./designer-form/time-designer";
+import {
+  DesignerForm as booleanDesignerForm,
+  schema as booleanSchema,
+  schemaEffect as booleanSchemaEffect,
+  toDefaultValue as booleanToDefaultValue,
+} from "./designer-form/boolean-designer";
+import {
+  DesignerForm as jsonDesignerForm,
+  schema as jsonSchema,
+  schemaEffect as jsonSchemaEffect,
+  toDefaultValue as jsonToDefaultValue,
+} from "./designer-form/json-designer";
+import {
+  DesignerForm as singleChoiceDesignerForm,
+  schema as singleChoiceSchema,
+  schemaEffect as singleChoiceSchemaEffect,
+  toDefaultValue as singleChoiceToDefaultValue,
+} from "./designer-form/single-select-designer";
+import {
+  DesignerForm as multipleChoiceDesignerForm,
+  schema as multipleChoiceSchema,
+  schemaEffect as multipleChoiceSchemaEffect,
+  toDefaultValue as multipleChoiceToDefaultValue,
+} from "./designer-form/multiple-select-designer";
+import {
+  DesignerForm as relationDesignerForm,
+  schema as relationSchema,
+  schemaEffect as relationEffect,
+  toDefaultValue as relationToDefaultValue,
+} from "./designer-form/relation-designer";
 
 import { ChangedFullEntity } from "@/types/entity";
 import { FormOpenMode } from "@/core-features/dynamic-form/form-field";
 
 export interface DesignerFormProps {
-    formMethods: UseFormReturn<any, any, undefined>;
-    openMode?: FormOpenMode;
+  formMethods: UseFormReturn<any, any, undefined>;
+  openMode?: FormOpenMode;
 }
 
 export type ChildTypeDescriptor = {
-    type: ApiFieldTypes;
-    icon: JSX.Element;
-    label: string;
-    description?: string;
-    disabled?: boolean,
-    schema?: z.ZodObject<any, any>,
-    schemaEffect?: null | ((schema: z.ZodObject<any, any>, editId: string | undefined, entity: ChangedFullEntity) => undefined | null | z.ZodEffects<any, any>),
-    toDefaultValue?: (value: any) => any,
-    formContent?: React.FC<{ formMethods: UseFormReturn<any, any, undefined>, openMode?: FormOpenMode }>
-}
+  type: ApiFieldTypes;
+  icon: JSX.Element;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  schema?: z.ZodObject<any, any>;
+  schemaEffect?:
+    | null
+    | ((
+        schema: z.ZodObject<any, any>,
+        editId: string | undefined,
+        entity: ChangedFullEntity,
+      ) => undefined | null | z.ZodEffects<any, any>);
+  toDefaultValue?: (value: any) => any;
+  formContent?: React.FC<{
+    formMethods: UseFormReturn<any, any, undefined>;
+    openMode?: FormOpenMode;
+  }>;
+};
 
 // export const designerEdges: Array<ChildTypeDescriptor> = [{
 //     type: 'Relation',
@@ -67,212 +145,240 @@ export type ChildTypeDescriptor = {
 //     description: 'Foreign key to another entity',
 // }]
 
-export const designerFields: Array<ChildTypeDescriptor> = [{
-    type: 'ID',
+export const designerFields: Array<ChildTypeDescriptor> = [
+  {
+    type: "ID",
     icon: <MdKey size={18} />,
-    label: 'Text Short',
-    description: 'Enter brief text',
-}, {
-    type: 'ShortText',
+    label: "Text Short",
+    description: "Enter brief text",
+  },
+  {
+    type: "ShortText",
     icon: <MdShortText size={18} />,
-    label: 'Text Short',
-    description: 'Enter brief text',
+    label: "Text Short",
+    description: "Enter brief text",
     //----
     schema: shortTextSchema,
     schemaEffect: shortTextSchemaEffect,
     toDefaultValue: shortTextToDefaultValue,
-    formContent: shortTextDesignerForm
-}, {
-    type: 'LongText',
+    formContent: shortTextDesignerForm,
+  },
+  {
+    type: "LongText",
     icon: <LuText size={18} />,
-    label: 'Text Long',
-    description: 'Enter extended text',
+    label: "Text Long",
+    description: "Enter extended text",
     //----
     schema: longTextSchema,
     schemaEffect: longTextSchemaEffect,
     toDefaultValue: longTextToDefaultValue,
-    formContent: longTextDesignerForm
-}, {
-    type: 'Email',
+    formContent: longTextDesignerForm,
+  },
+  {
+    type: "Email",
     icon: <MdAlternateEmail size={18} />,
-    label: 'Email',
-    description: 'Input email address',
+    label: "Email",
+    description: "Input email address",
     //----
     schema: emailSchema,
     schemaEffect: emailSchemaEffect,
     toDefaultValue: emailToDefaultValue,
-    formContent: emailDesignerForm
-}, {
-    type: 'RichText',
+    formContent: emailDesignerForm,
+  },
+  {
+    type: "RichText",
     icon: <DocumentIcon />,
-    label: 'Rich Text',
-    description: 'Format text richly',
+    label: "Rich Text",
+    description: "Format text richly",
     //----
     schema: rtfSchema,
     schemaEffect: rtfSchemaEffect,
     toDefaultValue: rtfToDefaultValue,
-    formContent: rtfDesignerForm
-}, {
-    type: 'Integer',
+    formContent: rtfDesignerForm,
+  },
+  {
+    type: "Markdown",
+    icon: <LuTextQuote size={18} />,
+    label: "Markdown",
+    description: "Markdown formatted text",
+    schema: longTextSchema,
+    schemaEffect: longTextSchemaEffect,
+    toDefaultValue: longTextToDefaultValue,
+    formContent: longTextDesignerForm,
+  },
+  {
+    type: "Integer",
     icon: <NumbersIcon />,
-    label: 'Number',
-    description: 'Input numerical number',
+    label: "Number",
+    description: "Input numerical number",
     //----
     schema: numberSchema,
     schemaEffect: numberSchemaEffect,
     toDefaultValue: numberToDefaultValue,
-    formContent: numberDesignerForm
-}, {
-    type: 'Decimal',
+    formContent: numberDesignerForm,
+  },
+  {
+    type: "Decimal",
     icon: <NumbersIcon />,
-    label: 'Decimal',
-    description: 'Input decimal number',
+    label: "Decimal",
+    description: "Input decimal number",
     //----
     schema: numberSchema,
     schemaEffect: numberSchemaEffect,
     toDefaultValue: numberToDefaultValue,
-    formContent: numberDesignerForm
-}, {
-    type: 'Float',
+    formContent: numberDesignerForm,
+  },
+  {
+    type: "Float",
     icon: <NumbersIcon />,
-    label: 'Float',
-    description: 'Input floating number',
+    label: "Float",
+    description: "Input floating number",
     //----
     schema: numberSchema,
     schemaEffect: numberSchemaEffect,
     toDefaultValue: numberToDefaultValue,
-    formContent: numberDesignerForm
-}, {
-    type: 'DateTime',
+    formContent: numberDesignerForm,
+  },
+  {
+    type: "DateTime",
     icon: <RiCalendarScheduleFill size={18} />,
-    label: 'Date Time',
-    description: 'Select date and time',
+    label: "Date Time",
+    description: "Select date and time",
     //----
     schema: dateTimeSchema,
     schemaEffect: dateTimeSchemaEffect,
     toDefaultValue: dateTimeToDefaultValue,
-    formContent: dateTimeDesignerForm
-}, {
-    type: 'Date',
+    formContent: dateTimeDesignerForm,
+  },
+  {
+    type: "Date",
     icon: <RiCalendarFill size={18} />,
-    label: 'Date',
-    description: 'Select a date',
+    label: "Date",
+    description: "Select a date",
     //----
     schema: dateSchema,
     schemaEffect: dateSchemaEffect,
     toDefaultValue: dateToDefaultValue,
-    formContent: dateDesignerForm
-}, {
-    type: 'Time',
+    formContent: dateDesignerForm,
+  },
+  {
+    type: "Time",
     icon: <TbClockFilled size={18} />,
-    label: 'Time',
-    description: 'Select a time',
+    label: "Time",
+    description: "Select a time",
     //----
     schema: timeSchema,
     schemaEffect: timeSchemaEffect,
     toDefaultValue: timeToDefaultValue,
-    formContent: timeDesignerForm
-}, {
-    type: 'media',
+    formContent: timeDesignerForm,
+  },
+  {
+    type: "media",
     icon: <PiMountainsFill size={18} />,
-    label: 'Media',
-    description: 'Upload image or video',
-    disabled: true
-}, {
-    type: 'Boolean',
+    label: "Media",
+    description: "Upload image or video",
+    disabled: true,
+  },
+  {
+    type: "Boolean",
     icon: <SwitchIcon />,
-    label: 'Boolean',
-    description: 'Toggle true/false',
+    label: "Boolean",
+    description: "Toggle true/false",
     //----
     schema: booleanSchema,
     schemaEffect: booleanSchemaEffect,
     toDefaultValue: booleanToDefaultValue,
-    formContent: booleanDesignerForm
-}, {
-    type: 'Json',
+    formContent: booleanDesignerForm,
+  },
+  {
+    type: "Json",
     icon: <BracesIcon />,
-    label: 'JSON',
-    description: 'Add JSON data',
+    label: "JSON",
+    description: "Add JSON data",
     //----
     schema: jsonSchema,
     schemaEffect: jsonSchemaEffect,
     toDefaultValue: jsonToDefaultValue,
-    formContent: jsonDesignerForm
-}, {
-    type: 'SingleChoice',
+    formContent: jsonDesignerForm,
+  },
+  {
+    type: "SingleChoice",
     icon: <MdPlaylistAddCheck size={18} />,
-    label: 'Single Choice',
-    description: 'Choose an option',
+    label: "Single Choice",
+    description: "Choose an option",
     //----
     schema: singleChoiceSchema,
     schemaEffect: singleChoiceSchemaEffect,
     toDefaultValue: singleChoiceToDefaultValue,
-    formContent: singleChoiceDesignerForm
-}, {
-    type: 'MultipleChoice',
+    formContent: singleChoiceDesignerForm,
+  },
+  {
+    type: "MultipleChoice",
     icon: <MdOutlineChecklistRtl size={18} />,
-    label: 'Multiple Choice',
-    description: 'Choose an option',
+    label: "Multiple Choice",
+    description: "Choose an option",
     //----
     schema: multipleChoiceSchema,
     schemaEffect: multipleChoiceSchemaEffect,
     toDefaultValue: multipleChoiceToDefaultValue,
-    formContent: multipleChoiceDesignerForm
-}, {
-    type: 'Relation',
+    formContent: multipleChoiceDesignerForm,
+  },
+  {
+    type: "Relation",
     icon: <PiGraphFill size={18} />,
-    label: 'Relation',
-    description: 'Foreign key to another entity',
+    label: "Relation",
+    description: "Foreign key to another entity",
     //----
     schema: relationSchema,
     schemaEffect: relationEffect,
     toDefaultValue: relationToDefaultValue,
-    formContent: relationDesignerForm
-}];
+    formContent: relationDesignerForm,
+  },
+];
 
 type DesignerFieldMap = {
-    [key in ApiFieldTypes]: ChildTypeDescriptor;
+  [key in ApiFieldTypes]: ChildTypeDescriptor;
 };
 
-export const designerFieldsMap: Record<ApiFieldTypes, ChildTypeDescriptor> = designerFields.reduce((map, field) => {
+export const designerFieldsMap: Record<ApiFieldTypes, ChildTypeDescriptor> =
+  designerFields.reduce((map, field) => {
     map[field.type] = field;
     return map;
-}, {} as DesignerFieldMap);
+  }, {} as DesignerFieldMap);
 
 // export const designerEdgeMap: Record<'Relation', ChildTypeDescriptor> = {
 //     Relation: designerEdges[0]
 // }
 
 export const getIconForEntityChild = (child: Field | Edge): ReactNode => {
+  const childType: ApiFieldTypes =
+    "type" in child ? (child.type as ApiFieldTypes) : "Relation";
+  const field = designerFieldsMap[childType];
+  if (field) {
+    return field.icon;
+  }
+  return <PiSpiral size={18} />;
+  //}
 
-    const childType: ApiFieldTypes = 'type' in child ? child.type as ApiFieldTypes : 'Relation';
-    const field = designerFieldsMap[childType]
-    if (field) {
-        return field.icon;
-    }
-    return <PiSpiral size={18} />;
-    //}
+  // if (child.__typename === 'Edge') {
+  //     const field = designerEdgeMap.Relation;
+  //     if (field) {
+  //         return field.icon;
+  //     }
+  //     return <PiSpiral size={18} />;
+  // }
 
-    // if (child.__typename === 'Edge') {
-    //     const field = designerEdgeMap.Relation;
-    //     if (field) {
-    //         return field.icon;
-    //     }
-    //     return <PiSpiral size={18} />;
-    // }
-
-    return <PiSpiral size={18} />;
-}
+  return <PiSpiral size={18} />;
+};
 
 export const getChildTypeForEntityChild = (child: Field | Edge): string => {
+  if (child.__typename === "Field") {
+    return child.type.toUpperCase();
+  }
 
-    if (child.__typename === 'Field') {
-        return child.type.toUpperCase();
-    }
+  if (child.__typename === "Edge") {
+    return child.relatedEntity.caption?.toUpperCase();
+  }
 
-    if (child.__typename === 'Edge') {
-        return child.relatedEntity.caption?.toUpperCase();
-    }
-
-    return '';
-}
+  return "";
+};

--- a/src/admin/src/features/entity-type-designer/designer-fields-groups.ts
+++ b/src/admin/src/features/entity-type-designer/designer-fields-groups.ts
@@ -1,55 +1,57 @@
 import { ChildTypeDescriptor, designerFieldsMap } from "./designer-field-map";
 
-
 export type DesignerFieldGroup = {
-    main: ChildTypeDescriptor,
-    children?: Array<ChildTypeDescriptor>
-}
+  main: ChildTypeDescriptor;
+  children?: Array<ChildTypeDescriptor>;
+};
 
 export const designerEdgesGroups: Array<DesignerFieldGroup> = [
-    {
-        main: designerFieldsMap.Relation,
-    }
-]
-
-export const designerFieldsGroups: Array<DesignerFieldGroup> = [
-    {
-        main: designerFieldsMap.ShortText,
-        children: [
-            designerFieldsMap.ShortText,
-            designerFieldsMap.LongText,
-            designerFieldsMap.RichText,
-            designerFieldsMap.Email
-        ]
-    }, {
-        main: designerFieldsMap.Integer,
-        children: [
-            designerFieldsMap.Integer,
-            designerFieldsMap.Decimal,
-            designerFieldsMap.Float,
-        ]
-    }, {
-        main: designerFieldsMap.DateTime,
-        children: [
-            designerFieldsMap.DateTime,
-            designerFieldsMap.Date,
-            designerFieldsMap.Time
-        ]
-    }, {
-        main: designerFieldsMap.Boolean
-    }, {
-        main: designerFieldsMap.SingleChoice,
-        children: [
-            designerFieldsMap.SingleChoice,
-            designerFieldsMap.MultipleChoice,
-        ]
-    }, {
-        main: designerFieldsMap.media,
-
-    }, {
-        main: designerFieldsMap.Json
-    }
+  {
+    main: designerFieldsMap.Relation,
+  },
 ];
 
-
-
+export const designerFieldsGroups: Array<DesignerFieldGroup> = [
+  {
+    main: designerFieldsMap.ShortText,
+    children: [
+      designerFieldsMap.ShortText,
+      designerFieldsMap.LongText,
+      designerFieldsMap.RichText,
+      designerFieldsMap.Markdown,
+      designerFieldsMap.Email,
+    ],
+  },
+  {
+    main: designerFieldsMap.Integer,
+    children: [
+      designerFieldsMap.Integer,
+      designerFieldsMap.Decimal,
+      designerFieldsMap.Float,
+    ],
+  },
+  {
+    main: designerFieldsMap.DateTime,
+    children: [
+      designerFieldsMap.DateTime,
+      designerFieldsMap.Date,
+      designerFieldsMap.Time,
+    ],
+  },
+  {
+    main: designerFieldsMap.Boolean,
+  },
+  {
+    main: designerFieldsMap.SingleChoice,
+    children: [
+      designerFieldsMap.SingleChoice,
+      designerFieldsMap.MultipleChoice,
+    ],
+  },
+  {
+    main: designerFieldsMap.media,
+  },
+  {
+    main: designerFieldsMap.Json,
+  },
+];

--- a/src/admin/src/hooks/use-dynamic-grid-columns.tsx
+++ b/src/admin/src/hooks/use-dynamic-grid-columns.tsx
@@ -1,309 +1,470 @@
-import dayjs from 'dayjs';
-import { MutableRefObject, ReactNode, useMemo, useRef } from 'react';
-import { ApiFieldTypes, FormFieldTypes } from '@/types/field-type-descriptor';
-import { localeConfig } from "@/config/locale-config"
-import CheckIcon from '@mui/icons-material/Check';
-import { ColumnDef, useResponsivePin, useRowExpansionStore } from 'mosaic-data-table';
-import { Edge, Field, RelationType } from '@/lib/apollo/graphql.entities';
-import { Avatar, Button, Chip, Stack, Typography } from '@mui/material';
+import dayjs from "dayjs";
+import { MutableRefObject, ReactNode, useMemo, useRef } from "react";
+import { ApiFieldTypes, FormFieldTypes } from "@/types/field-type-descriptor";
+import { localeConfig } from "@/config/locale-config";
+import CheckIcon from "@mui/icons-material/Check";
+import {
+  ColumnDef,
+  useResponsivePin,
+  useRowExpansionStore,
+} from "mosaic-data-table";
+import { Edge, Field, RelationType } from "@/lib/apollo/graphql.entities";
+import { Avatar, Button, Chip, Stack, Typography } from "@mui/material";
 // import { stringAvatar } from '@/lib/utils/avatar';
-import { stringToDate, stringToDateTime, stringToTime } from '@/core-features/dynamic-form/value-convertor';
-import { InlineAvatar } from '@/shared/components/avatar';
-import { useViewRelationStore } from '@/core-features/view-item/use-view-relation-store';
+import {
+  stringToDate,
+  stringToDateTime,
+  stringToTime,
+} from "@/core-features/dynamic-form/value-convertor";
+import { InlineAvatar } from "@/shared/components/avatar";
+import { useViewRelationStore } from "@/core-features/view-item/use-view-relation-store";
 
 export type ColumnOptions = {
-    hasSort?: boolean,
-    width?: number,
-}
+  hasSort?: boolean;
+  width?: number;
+};
 
 interface UseDynamicGridColumnsProps {
-    entityName: string,
-    fields?: Field[],
-    edges?: Edge[],
-    displayFieldName?: string,
-	openRelation: (entityName: string, edge: Edge, entryId: string) => void,
-    showId: boolean
+  entityName: string;
+  fields?: Field[];
+  edges?: Edge[];
+  displayFieldName?: string;
+  openRelation: (entityName: string, edge: Edge, entryId: string) => void;
+  showId: boolean;
 }
 export const useDynamicGridColumns = ({
-    entityName,
-    fields = [],
-    edges = [],
-    displayFieldName,
-    openRelation,
-    showId
+  entityName,
+  fields = [],
+  edges = [],
+  displayFieldName,
+  openRelation,
+  showId,
 }: UseDynamicGridColumnsProps): ColumnDef[] => {
+  const displayFieldPin = useResponsivePin({
+    pin: "left",
+    breakpoint: "sm",
+    direction: "up",
+  });
 
-    const displayFieldPin = useResponsivePin({ pin: 'left', breakpoint: 'sm', direction: 'up' });
+  const expansionStoreRef = useRef(openRelation);
+  expansionStoreRef.current = openRelation;
 
-    const expansionStoreRef = useRef(openRelation);
-    expansionStoreRef.current = openRelation;
-
-    return useMemo(() => (
-        [
-            ...fields
-                .filter(i => showId ? true : i.name != 'id')
-                .filter(i => !i.private) // TODO: this should be hidden from BE
-                .filter(i => i.type != 'RichText') // TODO: set RichText based on configuration
-                .filter(i => i.type != 'Json') // TODO: set JSON based on configuration
-                .map(i => fieldToColumn(i))
-                .map(i => i.id === displayFieldName ? {
-                    ...i,
-                    pin: displayFieldPin,
-                    highlight: true
-                } : i),
-            ...edges.map(i => edgeToColumn(entityName, i, expansionStoreRef)),
-        ]
-    ), [displayFieldPin, showId, displayFieldName, fields, edges]);
-}
-
+  return useMemo(
+    () => [
+      ...fields
+        .filter((i) => (showId ? true : i.name != "id"))
+        .filter((i) => !i.private) // TODO: this should be hidden from BE
+        .filter((i) => i.type != "RichText" && i.type != "Markdown") // TODO: set RichText based on configuration
+        .filter((i) => i.type != "Json") // TODO: set JSON based on configuration
+        .map((i) => fieldToColumn(i))
+        .map((i) =>
+          i.id === displayFieldName
+            ? {
+                ...i,
+                pin: displayFieldPin,
+                highlight: true,
+              }
+            : i,
+        ),
+      ...edges.map((i) => edgeToColumn(entityName, i, expansionStoreRef)),
+    ],
+    [displayFieldPin, showId, displayFieldName, fields, edges],
+  );
+};
 
 const fieldToColumn = (field: Field): ColumnDef<Field> => {
+  // Add avatar for name column
+  if (field.name == "name" && field.type == "ShortText") {
+    return shortTextColumnDef(
+      field.name,
+      field.caption,
+      (row: any) => {
+        const cellValue = row[field.name];
+        return (
+          <Stack direction="row" gap={1} alignItems="center">
+            <InlineAvatar name={cellValue} />
+            {cellValue}
+          </Stack>
+        );
+      },
+      {
+        width: 180,
+        hasSort: true,
+      },
+    );
+  }
 
-    // Add avatar for name column
-    if (field.name == 'name' && field.type == 'ShortText') {
-        return shortTextColumnDef(field.name, field.caption, (row: any) => {
-            const cellValue = row[field.name];
-            return (<Stack direction="row" gap={1} alignItems="center">
-                <InlineAvatar name={cellValue} />
-                {cellValue}
-            </Stack>)
-        }, {
-            width: 180,
-            hasSort: true
-        });
-    }
+  switch (field.type as ApiFieldTypes) {
+    case "ShortText":
+      return shortTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "LongText":
+      return longTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "RichText":
+      return richTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Markdown":
+      return longTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Integer":
+      return integerColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "DateTime":
+      return dateTimeColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Date":
+      return dateColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Time":
+      return timeColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Boolean":
+      return booleanColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "MultipleChoice":
+      return multiChoiceColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: false },
+      );
+    default:
+      return shortTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+  }
+};
 
-    switch (field.type as ApiFieldTypes) {
-        case 'ShortText': return shortTextColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'LongText': return longTextColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'RichText': return richTextColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'Integer': return integerColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'DateTime': return dateTimeColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'Date': return dateColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'Time': return timeColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'Boolean': return booleanColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'MultipleChoice': return multiChoiceColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: false });
-        default: return shortTextColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-    }
-}
+const edgeToColumn = (
+  entityName: string,
+  edge: Edge,
+  openRelation: MutableRefObject<
+    (entityName: string, edge: Edge, entryId: string) => void
+  >,
+): ColumnDef<Edge> => {
+  switch (edge.relationType) {
+    case RelationType.One:
+    case RelationType.OneToOne:
+    case RelationType.OneToMany:
+      return oneColumnDef(entityName, edge, openRelation);
+    case RelationType.Many:
+    case RelationType.ManyToOne:
+    case RelationType.ManyToMany:
+      return manyColumnDef(entityName, edge, openRelation);
+  }
 
-const edgeToColumn = (entityName: string, edge: Edge, openRelation: MutableRefObject<(entityName: string, edge: Edge, entryId: string) => void>): ColumnDef<Edge> => {
+  return {
+    id: edge.name,
+    header: "",
+    cell: (row: any) => "",
+  };
+};
 
-    switch (edge.relationType) {
-        case RelationType.One:
-        case RelationType.OneToOne:
-        case RelationType.OneToMany:
-            return oneColumnDef(entityName, edge, openRelation);
-        case RelationType.Many:
-        case RelationType.ManyToOne:
-        case RelationType.ManyToMany:
-            return manyColumnDef(entityName, edge, openRelation);
-    }
+const shortTextColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => ReactNode,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => render(row),
+    width: options?.width ?? 180,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-    return {
-        id: edge.name,
-        header: '',
-        cell: (row: any) => ''
-    }
-}
+const longTextColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => render(row),
+    width: options?.width ?? 300,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-const shortTextColumnDef = (name: string, caption: string, render: (row: any) => ReactNode, options?: ColumnOptions): ColumnDef<any> => {
+const richTextColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => render(row),
+    width: options?.width ?? 300,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => render(row),
-        width: options?.width ?? 180,
-        hasSort: options?.hasSort ?? false
-    };
-}
+const integerColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => number,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => render(row),
+    width: options?.width ?? 150,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-const longTextColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => render(row),
-        width: options?.width ?? 300,
-        hasSort: options?.hasSort ?? false
-    };
-}
+const dateTimeColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
+      if (!value) {
+        return "";
+      }
 
-const richTextColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => render(row),
-        width: options?.width ?? 300,
-        hasSort: options?.hasSort ?? false
-    };
-}
+      return (
+        stringToDateTime(value)?.format(localeConfig.dateTime.displayFormat) ??
+        undefined
+      );
+    },
+    width: options?.width ?? 210,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-const integerColumnDef = (name: string, caption: string, render: (row: any) => number, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => render(row),
-        width: options?.width ?? 150,
-        hasSort: options?.hasSort ?? false
-    };
-}
+const dateColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
+      if (!value) {
+        return "";
+      }
 
-const dateTimeColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
+      return (
+        stringToDate(value)?.format(localeConfig.date.displayFormat) ??
+        undefined
+      );
+    },
+    width: options?.width ?? 120,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-            const value = render(row);
-            if (!value) {
-                return '';
-            }
+const timeColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
+      if (!value) {
+        return "";
+      }
 
-            return stringToDateTime(value)?.format(localeConfig.dateTime.displayFormat) ?? undefined;
+      return (
+        stringToTime(value)?.format(localeConfig.time.displayFormat) ??
+        undefined
+      );
+    },
+    width: options?.width ?? 180,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-        },
-        width: options?.width ?? 210,
-        hasSort: options?.hasSort ?? false
-    };
-}
+const booleanColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
+      if (!value) {
+        return "";
+      }
 
-const dateColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
+      return <CheckIcon />;
+    },
+    width: options?.width ?? 120,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-            const value = render(row);
-            if (!value) {
-                return '';
-            }
+const multiChoiceColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
 
-            return stringToDate(value)?.format(localeConfig.date.displayFormat) ?? undefined;
+      if (!Array.isArray(value)) {
+        return value;
+      }
 
-        },
-        width: options?.width ?? 120,
-        hasSort: options?.hasSort ?? false
-    };
-}
+      return (
+        <Stack direction="row" gap="3px">
+          {value.map((i) => {
+            return <Chip key={i} label={i} size="small" variant="outlined" />;
+          })}
+        </Stack>
+      );
+    },
+    width: options?.width ?? 120,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-const timeColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
+const oneColumnDef = (
+  entityName: string,
+  edge: Edge,
+  openRelation: MutableRefObject<
+    (entityName: string, edge: Edge, entryId: string) => void
+  >,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: edge.name,
+    header: edge.caption,
+    cell: (row: any) => {
+      const entityValue = row[edge.name];
+      if (!entityValue) {
+        return "";
+      }
 
-            const value = render(row);
-            if (!value) {
-                return '';
-            }
+      const displayValue =
+        entityValue[edge.relatedEntity.displayField.name] ||
+        `Id: ${entityValue["id"]}`;
 
-            return stringToTime(value)?.format(localeConfig.time.displayFormat) ?? undefined;
+      return (
+        <Button
+          variant="text"
+          sx={{
+            padding: 0,
+          }}
+          onClick={() => {
+            openRelation.current(entityName, edge, row.id);
+          }}
+        >
+          <Typography
+            color="text.primary"
+            variant="body2"
+            sx={{ textDecoration: "underline" }}
+          >
+            {displayValue}
+          </Typography>
+        </Button>
+      );
+    },
+    width: options?.width ?? 180,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-        },
-        width: options?.width ?? 180,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
-const booleanColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
-
-            const value = render(row);
-            if (!value) {
-                return '';
-            }
-
-            return (<CheckIcon />)
-
-        },
-        width: options?.width ?? 120,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
-const multiChoiceColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
-
-            const value = render(row);
-
-            if (!Array.isArray(value)) {
-                return value;
-            }
-
-            return (<Stack direction="row" gap="3px">
-                {value.map((i) => {
-                    return (<Chip key={i} label={i} size="small" variant="outlined" />)
-                })}
-            </Stack>
-            )
-
-        },
-        width: options?.width ?? 120,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
-const oneColumnDef = (entityName: string, edge: Edge, openRelation: MutableRefObject<(entityName: string, edge: Edge, entryId: string) => void>, options?: ColumnOptions): ColumnDef<any> => {
-
-    return {
-        id: edge.name,
-        header: edge.caption,
-        cell: (row: any) => {
-            const entityValue = row[edge.name];
-            if (!entityValue) {
-                return '';
-            }
-
-            const displayValue = entityValue[edge.relatedEntity.displayField.name] || `Id: ${entityValue['id']}`;
-
-            return <Button
-                variant="text"
-                sx={{
-                    padding: 0
-                }}
-                onClick={() => {
-					openRelation.current(entityName, edge, row.id);
-                }}>
-                <Typography
-                    color="text.primary"
-                    variant='body2'
-                    sx={{ textDecoration: 'underline' }}>{displayValue}</Typography></Button>
-        },
-        width: options?.width ?? 180,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
-const manyColumnDef = (entityName: string, edge: Edge, openRelation: MutableRefObject<(entityName: string, edge: Edge, entryId: string) => void>, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: edge.name,
-        header: edge.caption,
-        cell: (row: any) => {
-
-            return <Button
-                variant="text"
-                sx={{
-                    padding: 0
-                }}
-                onClick={() => {
-
-					openRelation.current(entityName, edge, row.id);
-
-                }}>
-                <Typography
-                    color="text.primary"
-                    variant='body2'
-                    sx={{ textDecoration: 'underline' }}>VIEW</Typography>
-            </Button>
-        },
-        width: options?.width ?? 180,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
+const manyColumnDef = (
+  entityName: string,
+  edge: Edge,
+  openRelation: MutableRefObject<
+    (entityName: string, edge: Edge, entryId: string) => void
+  >,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: edge.name,
+    header: edge.caption,
+    cell: (row: any) => {
+      return (
+        <Button
+          variant="text"
+          sx={{
+            padding: 0,
+          }}
+          onClick={() => {
+            openRelation.current(entityName, edge, row.id);
+          }}
+        >
+          <Typography
+            color="text.primary"
+            variant="body2"
+            sx={{ textDecoration: "underline" }}
+          >
+            VIEW
+          </Typography>
+        </Button>
+      );
+    },
+    width: options?.width ?? 180,
+    hasSort: options?.hasSort ?? false,
+  };
+};

--- a/src/admin/src/lib/utils/get-filters-from-query.ts
+++ b/src/admin/src/lib/utils/get-filters-from-query.ts
@@ -1,64 +1,80 @@
 import { AdvancedFilter } from "@/core-features/dynamic-filter/filter";
-import { containsFoldOperator, eqNumberOperator, eqBooleanOperator } from "@/core-features/dynamic-filter/filter-operators";
+import {
+  containsFoldOperator,
+  eqNumberOperator,
+  eqBooleanOperator,
+} from "@/core-features/dynamic-filter/filter-operators";
 import { Field } from "@/lib/apollo/graphql.entities";
 
+export const getAdvancedFiltersFromQuery = (
+  query: string,
+  fields: Field[],
+): AdvancedFilter[] => {
+  if (!query) {
+    return [];
+  }
 
-export const getAdvancedFiltersFromQuery = (query: string, fields: Field[]): AdvancedFilter[] => {
-    if (!query) {
-        return [];
-    }
+  const reusult = [
+    ...getStringQuery(query, fields),
+    ...getIntegerQuery(query, fields),
+    ...getBooleanQuery(query, fields),
+  ];
 
-    const reusult = [
-        ...getStringQuery(query, fields),
-        ...getIntegerQuery(query, fields),
-        ...getBooleanQuery(query, fields)
-    ];
-
-    return reusult;
-}
+  return reusult;
+};
 
 const getStringQuery = (query: string, fields: Field[]): AdvancedFilter[] => {
-    return fields.filter(i => 
-        i.type == 'ID'
-        || i.type == 'ShortText'
-        || i.type == 'LongText'
-        || i.type == 'RichText'
-        || i.type == 'Email'
-        || i.type == 'Json'
-        || i.type == 'SingleChoice'
-    ).map(i => ({
-        property: i.name,
-        operator: containsFoldOperator.name,
-        value: query
+  return fields
+    .filter(
+      (i) =>
+        i.type == "ID" ||
+        i.type == "ShortText" ||
+        i.type == "LongText" ||
+        i.type == "RichText" ||
+        i.type == "Markdown" ||
+        i.type == "Email" ||
+        i.type == "Json" ||
+        i.type == "SingleChoice",
+    )
+    .map((i) => ({
+      property: i.name,
+      operator: containsFoldOperator.name,
+      value: query,
     }));
-}
+};
 
 const getIntegerQuery = (query: string, fields: Field[]): AdvancedFilter[] => {
+  const numberValue = parseInt(query);
+  if (isNaN(numberValue)) {
+    return [];
+  }
 
-    const numberValue = parseInt(query);
-    if (isNaN(numberValue)) {
-        return [];
-    }
-
-    return fields.filter(i => i.type == 'Integer'
-        || i.type == 'Decimal'
-        || i.type == 'Float'
-    ).map(i => ({
-        property: i.name,
-        operator: eqNumberOperator.name,
-        value: numberValue
+  return fields
+    .filter(
+      (i) => i.type == "Integer" || i.type == "Decimal" || i.type == "Float",
+    )
+    .map((i) => ({
+      property: i.name,
+      operator: eqNumberOperator.name,
+      value: numberValue,
     }));
-}
+};
 
 const getBooleanQuery = (query: string, fields: Field[]): AdvancedFilter[] => {
-    const boolField = fields.find(i => i.type == 'Boolean' && i.caption.toLocaleLowerCase() == query.toLocaleLowerCase());
-    if(!boolField){
-        return [];
-    }
+  const boolField = fields.find(
+    (i) =>
+      i.type == "Boolean" &&
+      i.caption.toLocaleLowerCase() == query.toLocaleLowerCase(),
+  );
+  if (!boolField) {
+    return [];
+  }
 
-    return [{
-        property: boolField!.name,
-        operator: eqBooleanOperator.name,
-        value: true
-    }];
-}
+  return [
+    {
+      property: boolField!.name,
+      operator: eqBooleanOperator.name,
+      value: true,
+    },
+  ];
+};

--- a/src/admin/src/shared/components/markdown/MarkdownEditor.tsx
+++ b/src/admin/src/shared/components/markdown/MarkdownEditor.tsx
@@ -1,0 +1,23 @@
+"use client";
+import dynamic from "next/dynamic";
+import { InputBaseComponentProps } from "@mui/material";
+import { forwardRef } from "react";
+const MDEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
+export const MarkdownEditor = forwardRef<
+  HTMLDivElement,
+  InputBaseComponentProps
+>(function MarkdownEditor(props, ref) {
+  return (
+    <div ref={ref} style={{ width: "100%" }} data-color-mode="light">
+      <MDEditor
+        value={(props.value as string) ?? ""}
+        onChange={(val) =>
+          props.onChange?.({
+            target: { name: props.name, value: val ?? "" },
+          } as any)
+        }
+        onBlur={props.onBlur as any}
+      />
+    </div>
+  );
+});

--- a/src/admin/src/types/field-type-descriptor.ts
+++ b/src/admin/src/types/field-type-descriptor.ts
@@ -1,7 +1,51 @@
 import { FC, ReactNode } from "react";
 
-export type FieldScalarTypes = 'ID' | 'ShortText' | 'LongText' | 'Email' | 'RichText' | 'Password' | 'Integer' | 'Decimal' | 'Float' | 'DateTime' | 'Date' | 'Time' | 'media' | 'Boolean' | 'Json' | 'Enum' | 'SingleChoice' | 'MultipleChoice';
-export type EdgeRelationTypes = 'Relation';
+export type FieldScalarTypes =
+  | "ID"
+  | "ShortText"
+  | "LongText"
+  | "Email"
+  | "RichText"
+  | "Markdown"
+  | "Password"
+  | "Integer"
+  | "Decimal"
+  | "Float"
+  | "DateTime"
+  | "Date"
+  | "Time"
+  | "media"
+  | "Boolean"
+  | "Json"
+  | "Enum"
+  | "SingleChoice"
+  | "MultipleChoice";
+export type EdgeRelationTypes = "Relation";
 export type ApiFieldTypes = FieldScalarTypes | EdgeRelationTypes;
 
-export type FormFieldTypes = 'ShortText' | 'LongText' | 'RichText' | 'Password' | 'Number' | 'Boolean' | 'BooleanSelect' | 'DateTime' | 'Date' | 'Time' | 'Json' | 'Select' | 'TagsSelect' | 'SingleChoice' | 'MultipleChoice' | 'RelationOne' | 'RelationMany' | 'Select' | 'TagsSelect' | 'BooleanSelect' | 'Autocomplete' | 'EntitySelector' | 'RelationOne' | 'RelationMany';
+export type FormFieldTypes =
+  | "ShortText"
+  | "LongText"
+  | "RichText"
+  | "Markdown"
+  | "Password"
+  | "Number"
+  | "Boolean"
+  | "BooleanSelect"
+  | "DateTime"
+  | "Date"
+  | "Time"
+  | "Json"
+  | "Select"
+  | "TagsSelect"
+  | "SingleChoice"
+  | "MultipleChoice"
+  | "RelationOne"
+  | "RelationMany"
+  | "Select"
+  | "TagsSelect"
+  | "BooleanSelect"
+  | "Autocomplete"
+  | "EntitySelector"
+  | "RelationOne"
+  | "RelationMany";

--- a/src/api/domain/svc/entity_test.go
+++ b/src/api/domain/svc/entity_test.go
@@ -164,6 +164,69 @@ var _ = Describe("Create Entity", func() {
 				_, err := e.CreateEntity(ctx, createInput)
 				Expect(err).To(BeNil())
 			})
+			Context("Entity with markdown field", func() {
+				var createFieldInput entity.CreateFieldInput
+				BeforeEach(func() {
+					createInput = entity.CreateEntityInput{
+						Caption: "Test Entity",
+						DisplayField: entity.FieldWhereUniqueInput{
+							Name: P("id"),
+						},
+						Fields: &entity.CreateManyFieldsInput{
+							Create: []*entity.CreateFieldInput{},
+						},
+					}
+					createFieldInput = entity.CreateFieldInput{
+						Caption: "Md",
+						Type:    string(entity.FieldTypeMarkdown),
+					}
+				})
+
+				It("Will create markdown field", func() {
+					mockSchemaManager.EXPECT().BackupSchema().Return(nil)
+					mockSchemaManager.EXPECT().Generate(gomock.Any(), gomock.Any()).Return(nil)
+					mockSchemaManager.EXPECT().WriteEntityToSchema(Matches(
+						MatchFields(IgnoreExtras, Fields{
+							"Entity": MatchAllFields(Fields{
+								"Name":             Equal("testEntity"),
+								"EntName":          Equal("TestEntity"),
+								"Caption":          Equal("Test Entity"),
+								"Owner":            Equal(entity.EntityOwnerUser),
+								"DisplayFieldName": Equal("id"),
+							}),
+							"Fields": MatchAllElementsWithIndex(IndexIdentity, Elements{
+								"0": idFieldMatcher,
+								"1": createdAtMatcher,
+								"2": updatedAtMatcher,
+								"3": MatchAllFields(Fields{
+									"Name":           Equal("md"),
+									"EntName":        Equal("md"),
+									"Caption":        Equal("Md"),
+									"Type":           Equal(string(entity.FieldTypeMarkdown)),
+									"Required":       BeNil(),
+									"Unique":         BeNil(),
+									"DefaultValue":   BeNil(),
+									"Min":            BeNil(),
+									"Max":            BeNil(),
+									"Private":        BeNil(),
+									"Nillable":       Equal(false),
+									"UpdateDefault":  Equal(false),
+									"AcceptedValues": BeNil(),
+								}),
+							}),
+							"Edges": MatchAllElementsWithIndex(IndexIdentity, Elements{
+								"0": createdByMatcher,
+								"1": updatedByMatcher,
+							}),
+							"RelatedEntities": BeEmpty(),
+						}),
+					)).Return(nil)
+
+					createInput.Fields.Create = append(createInput.Fields.Create, &createFieldInput)
+					_, err := e.CreateEntity(ctx, createInput)
+					Expect(err).To(BeNil())
+				})
+			})
 		})
 		Context("Entity with short text field", func() {
 			var createFieldInput entity.CreateFieldInput

--- a/src/api/entgql/entity/field.go
+++ b/src/api/entgql/entity/field.go
@@ -98,6 +98,7 @@ const (
 	FieldTypeShortText      FieldType = "ShortText"
 	FieldTypeLongText       FieldType = "LongText"
 	FieldTypeRichText       FieldType = "RichText"
+	FieldTypeMarkdown       FieldType = "Markdown"
 	FieldTypeEmail          FieldType = "Email"
 	FieldTypeInteger        FieldType = "Integer"
 	FieldTypeDecimal        FieldType = "Decimal"

--- a/src/api/entgql/generator/generator.go
+++ b/src/api/entgql/generator/generator.go
@@ -200,6 +200,8 @@ func Imports(fields []entity.Field) map[string]bool {
 			imports["entgo.io/ent/dialect"] = true
 		case entity.FieldTypeRichText:
 			imports["entgo.io/ent/dialect"] = true
+		case entity.FieldTypeMarkdown:
+			imports["entgo.io/ent/dialect"] = true
 		case entity.FieldTypeEmail:
 		case entity.FieldTypeInteger:
 		case entity.FieldTypeDecimal:

--- a/src/api/entgql/templates/entschema/entity.go.tmpl
+++ b/src/api/entgql/templates/entschema/entity.go.tmpl
@@ -49,6 +49,8 @@ func ({{$.Entity.EntName}}) Fields() []ent.Field {
             {{template "LongText" $f}}
         {{- else if eq $f.Type "RichText" }}
             {{template "RichText" $f}}
+        {{- else if eq $f.Type "Markdown" }}
+            {{template "Markdown" $f}}
         {{- else if eq $f.Type "Email" }}
             {{template "Email" $f}}
         {{- else if eq $f.Type "Integer" }}

--- a/src/api/entgql/templates/entschema/markdown.go.tmpl
+++ b/src/api/entgql/templates/entschema/markdown.go.tmpl
@@ -1,0 +1,21 @@
+{{- define "Markdown"}}
+                field.String("{{$.EntName}}").
+                        {{- if $.Required | IsFalse  }}
+                        Optional().
+            Nillable().
+                        {{- end}}
+                        SchemaType(map[string]string{
+                                dialect.MySQL:    "MEDIUMTEXT",
+                                dialect.Postgres: "TEXT",
+                        }).
+                        Annotations(
+                                entgql.OrderField("{{$.EntName | CamelCase}}"),
+                                annotations.Field{
+                                        Caption:   "{{$.Caption}}",
+                                        Type: entity.FieldTypeMarkdown,
+                                        {{- if $.Private }}
+                                        Private: {{$.Private}},
+                                        {{- end }}
+                                },
+                        ),
+{{- end}}


### PR DESCRIPTION
## Summary
- add `Markdown` field type to backend schemas and code generator
- support Markdown in admin forms and filters
- add Markdown editor component using `@uiw/react-md-editor`
- update dynamic grid handling and designer to include Markdown
- extend tests for service entity with Markdown field

## Testing
- `go test ./...` *(fails: strcase_test)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e849b3c90832c93ef0be00f5b8e2b