### PR TITLE
Add Markdown field type

### DIFF
--- a/src/admin/package.json
+++ b/src/admin/package.json
@@ -72,6 +72,7 @@
     "jwt-decode": "^4.0.0",
     "mosaic-data-table": "^0.0.52",
     "mui-tiptap": "^1.18.1",
+    "@uiw/react-md-editor": "^4.0.8",
     "next": "14.2.2",
     "notistack": "^3.0.2",
     "numeral": "^2.0.6",

--- a/src/admin/src/core-features/dynamic-form/form-elements-maps.ts
+++ b/src/admin/src/core-features/dynamic-form/form-elements-maps.ts
@@ -6,6 +6,7 @@ import { DateTimeFormField } from "@/core-features/dynamic-form/form-fields/Date
 import { TimeFormField } from "@/core-features/dynamic-form/form-fields/TimeField";
 import { TextLongFormField } from "@/core-features/dynamic-form/form-fields/TextLongField";
 import { RichTextFormField } from "@/core-features/dynamic-form/form-fields/RichTextField";
+import { MarkdownFormField } from "@/core-features/dynamic-form/form-fields/MarkdownField";
 import { DateFormField } from "@/core-features/dynamic-form/form-fields/DateField";
 import { JSONFormField } from "@/core-features/dynamic-form/form-fields/JSONField";
 import { SelectFormField } from "@/core-features/dynamic-form/form-fields/SelectField";
@@ -18,29 +19,29 @@ import { MultipleChoiceFormField } from "@/core-features/dynamic-form/form-field
 import { TagsSelectFormField } from "@/core-features/dynamic-form/form-fields/TagsSelectField";
 import { PasswordFormField } from "./form-fields/PasswordField";
 
-export const FormElementsMap = { 
-    ShortText: TextShortFormField,
-    LongText: TextLongFormField,
-    RichText: RichTextFormField,
-    Password: PasswordFormField,
-    
-    Number: NumberFormField,
+export const FormElementsMap = {
+  ShortText: TextShortFormField,
+  LongText: TextLongFormField,
+  RichText: RichTextFormField,
+  Markdown: MarkdownFormField,
+  Password: PasswordFormField,
 
-    Boolean: BooleanFormField,
-    BooleanSelect: BooleanSelectFormField,
+  Number: NumberFormField,
 
-    DateTime: DateTimeFormField,
-    Date: DateFormField,
-    Time: TimeFormField,
+  Boolean: BooleanFormField,
+  BooleanSelect: BooleanSelectFormField,
 
-    Json: JSONFormField,
+  DateTime: DateTimeFormField,
+  Date: DateFormField,
+  Time: TimeFormField,
 
-    Select: SelectFormField,
-    TagsSelect: TagsSelectFormField,
+  Json: JSONFormField,
 
-    SingleChoice: SingleChoiceFormField,
-    MultipleChoice: MultipleChoiceFormField,
-    RelationOne: LookupOneFIELDFormField,
-    RelationMany: LookupManyFIELDFormField, 
+  Select: SelectFormField,
+  TagsSelect: TagsSelectFormField,
 
-} as {[key in FormFieldTypes]: React.FC<any>};
+  SingleChoice: SingleChoiceFormField,
+  MultipleChoice: MultipleChoiceFormField,
+  RelationOne: LookupOneFIELDFormField,
+  RelationMany: LookupManyFIELDFormField,
+} as { [key in FormFieldTypes]: React.FC<any> };

--- a/src/admin/src/core-features/dynamic-form/form-fields/MarkdownField.tsx
+++ b/src/admin/src/core-features/dynamic-form/form-fields/MarkdownField.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import {
+  FilledInput,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+} from "@mui/material";
+import { get, useFormContext } from "react-hook-form";
+import useId from "@mui/material/utils/useId";
+import { useLiteController } from "../lite-controller";
+import { useFormDynamicContext } from "@/core-features/dynamic-form2/dynamic-form";
+import { MarkdownEditor } from "@/shared/components/markdown-editor";
+
+interface MarkdownFormComponentProps {
+  name: string;
+  label: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  errors?: any;
+
+  value: any;
+  onChange: (event: any) => void;
+  onBlur: (event: any) => void;
+}
+
+export function MarkdownFormComponent(props: MarkdownFormComponentProps) {
+  const {
+    name,
+    label,
+    placeholder,
+    disabled,
+    errors,
+    value,
+    onChange,
+    onBlur,
+  } = props;
+
+  const id = useId();
+  return (
+    <FormControl fullWidth variant="filled" error={!!errors}>
+      <InputLabel htmlFor={id} id={`${id}-label`}>
+        {label}
+      </InputLabel>
+      <FilledInput
+        fullWidth
+        inputComponent={MarkdownEditor as any}
+        placeholder={placeholder}
+        disabled={disabled}
+        id={id}
+        name={name}
+        value={value ?? ""}
+        onChange={onChange}
+        sx={{ overflow: "inherit", padding: 0 }}
+      />
+      {errors && <FormHelperText>{errors}</FormHelperText>}
+    </FormControl>
+  );
+}
+
+interface FormFieldProps {
+  name: string;
+  placeholder?: string;
+  label: string;
+  disabled?: boolean;
+  hide?: boolean;
+  required?: boolean;
+}
+export function MarkdownFormField(props: FormFieldProps) {
+  useFormDynamicContext(props.name, { disabled: props.disabled });
+  const formContext = useFormContext();
+  const formControllerHandler = useLiteController({
+    name: props.name,
+    control: formContext.control,
+    disabled: props.disabled,
+  });
+  useFormDynamicContext(props.name, {
+    disabled: formControllerHandler.disabled,
+  });
+
+  if (props.hide) {
+    return null;
+  }
+
+  const errors = get(formContext.formState.errors, props.name);
+
+  return (
+    <MarkdownFormComponent
+      label={props.label}
+      placeholder={props.placeholder}
+      required={props.required}
+      errors={errors?.message}
+      {...formControllerHandler}
+    />
+  );
+}

--- a/src/admin/src/features/content-manager/use-content-manager-form-schema.tsx
+++ b/src/admin/src/features/content-manager/use-content-manager-form-schema.tsx
@@ -1,12 +1,27 @@
-import { Edge, Entity, Field, RelationType } from "@/lib/apollo/graphql.entities";
+import {
+  Edge,
+  Entity,
+  Field,
+  RelationType,
+} from "@/lib/apollo/graphql.entities";
 import { ReactNode, useCallback, useMemo } from "react";
 import { FullEntity } from "@/types/entity";
 import { z } from "zod";
 import { TextShortFormField } from "@/core-features/dynamic-form/form-fields/TextShortField";
 import { TextLongFormField } from "@/core-features/dynamic-form/form-fields/TextLongField";
 import { RichTextFormField } from "@/core-features/dynamic-form/form-fields/RichTextField";
+import { MarkdownFormField } from "@/core-features/dynamic-form/form-fields/MarkdownField";
 import { NumberFormField } from "@/core-features/dynamic-form/form-fields/NumberField";
-import { dateTimeToString, dateTimeToStringPrecision, dateToString, stringToDate, stringToDateTime, stringToTime, timeToString, timeToStringPrecision } from "@/core-features/dynamic-form/value-convertor";
+import {
+  dateTimeToString,
+  dateTimeToStringPrecision,
+  dateToString,
+  stringToDate,
+  stringToDateTime,
+  stringToTime,
+  timeToString,
+  timeToStringPrecision,
+} from "@/core-features/dynamic-form/value-convertor";
 import { DateTimeFormField } from "@/core-features/dynamic-form/form-fields/DateTimeField";
 import { TimeFormField } from "@/core-features/dynamic-form/form-fields/TimeField";
 import { DateFormField } from "@/core-features/dynamic-form/form-fields/DateField";
@@ -14,699 +29,857 @@ import { BooleanSelectFormField } from "@/core-features/dynamic-form/form-fields
 import { JSONFormField } from "@/core-features/dynamic-form/form-fields/JSONField";
 import { SingleChoiceFormField } from "@/core-features/dynamic-form/form-fields/SingleChoice";
 import dayjs, { Dayjs } from "dayjs";
-import { LookupManyFIELDFormField, OptionTag as OptionTagMany } from "@/core-features/dynamic-form/form-fields/LookupManyFIELD";
-import { LookupOneFIELDFormField, OptionTag as OptionTagOne } from "@/core-features/dynamic-form/form-fields/LookupOneFIELD";
+import {
+  LookupManyFIELDFormField,
+  OptionTag as OptionTagMany,
+} from "@/core-features/dynamic-form/form-fields/LookupManyFIELD";
+import {
+  LookupOneFIELDFormField,
+  OptionTag as OptionTagOne,
+} from "@/core-features/dynamic-form/form-fields/LookupOneFIELD";
 import { Options, Option } from "@/core-features/dynamic-form/form-field";
 import { MultipleChoiceFormField } from "@/core-features/dynamic-form/form-fields/MultipleChoice";
 import { isJsonOrNull, toJsonOrNull } from "@/lib/utils/is-json";
 
 type FieldDetails = {
-	schema: z.ZodTypeAny;
-	input: ReactNode;
-	convertFromRawValue?: (value: any) => any;
-}
+  schema: z.ZodTypeAny;
+  input: ReactNode;
+  convertFromRawValue?: (value: any) => any;
+};
 
 const getShortText = (field: Field): FieldDetails => {
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z.string().optional().nullish();
+  })();
 
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? '',
-				z.string().min(1, `${field.caption} is required`)
-			);
-		}
-		return z.string().optional().nullish();
-	})();
-
-	return {
-		schema,
-		input: <TextShortFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} />
-	}
-}
+  return {
+    schema,
+    input: (
+      <TextShortFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
 const getLongText = (field: Field): FieldDetails => {
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z.string().optional().nullish();
+  })();
 
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? '',
-				z.string().min(1, `${field.caption} is required`)
-			);
-		}
-		return z.string().optional().nullish();
-	})();
-
-	return {
-		schema,
-		input: <TextLongFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} />
-	}
-}
-
+  return {
+    schema,
+    input: (
+      <TextLongFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
 const getRichText = (field: Field): FieldDetails => {
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z.string().optional().nullish();
+  })();
 
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? '',
-				z.string().min(1, `${field.caption} is required`)
-			);
-		}
-		return z.string().optional().nullish();
-	})();
+  return {
+    schema,
+    input: (
+      <RichTextFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
-	return {
-		schema,
-		input: <RichTextFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} />
-	}
-}
+const getMarkdown = (field: Field): FieldDetails => {
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z.string().optional().nullish();
+  })();
+
+  return {
+    schema,
+    input: (
+      <MarkdownFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
 const getEmail = (field: Field): FieldDetails => {
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(
-				(val) => (typeof val === "string" ? val.trim() : val),
-				z.string().min(1, `${field.caption} is required`).email('Invalid Email')
-			);
-		}
-		return z.preprocess(
-			(val) => (typeof val === "string" && val.trim() === "" ? undefined : val),
-			z.string().email("Invalid Email").optional().nullish()
-		);
-	})();
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (val) => (typeof val === "string" ? val.trim() : val),
+        z
+          .string()
+          .min(1, `${field.caption} is required`)
+          .email("Invalid Email"),
+      );
+    }
+    return z.preprocess(
+      (val) => (typeof val === "string" && val.trim() === "" ? undefined : val),
+      z.string().email("Invalid Email").optional().nullish(),
+    );
+  })();
 
-	return {
-		schema,
-		input: <TextShortFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} />
-	}
-}
+  return {
+    schema,
+    input: (
+      <TextShortFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+      />
+    ),
+  };
+};
 
 const getNumber = (field: Field): FieldDetails => {
+  // 1) Normalize empty → null, otherwise pass through to z.coerce.number()
+  let schema: z.ZodTypeAny = z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    return value;
+  }, z.coerce.number().nullable());
 
-	// 1) Normalize empty → null, otherwise pass through to z.coerce.number()
-	let schema: z.ZodTypeAny = z.preprocess((value) => {
-		if (value === null || value === undefined || value === "") {
-			return null;
-		}
-		return value;
-	}, z.coerce.number().nullable());
+  // 2) If required, disallow null
+  if (field.required) {
+    schema = schema.refine((val) => val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
-	// 2) If required, disallow null
-	if (field.required) {
-		schema = schema.refine((val) => val !== null, {
-			message: `${field.caption} is required`,
-		});
-	}
+  // Helper: only run test when there _is_ a number
+  const isNullOr = (fn: (n: number) => boolean) => (val: number | null) =>
+    val === null || fn(val);
 
-	// Helper: only run test when there _is_ a number
-	const isNullOr = (fn: (n: number) => boolean) =>
-		(val: number | null) => val === null || fn(val);
+  // 3) Min check (if configured)
+  if (field.min != null) {
+    const minVal = +field.min;
+    schema = schema.refine(
+      isNullOr((n) => n >= minVal),
+      { message: `${field.caption} must be ≥ ${minVal}` },
+    );
+  }
 
-	// 3) Min check (if configured)
-	if (field.min != null) {
-		const minVal = +field.min;
-		schema = schema.refine(
-			isNullOr((n) => n >= minVal),
-			{ message: `${field.caption} must be ≥ ${minVal}` }
-		);
-	}
+  // 4) Max check (if configured)
+  if (field.max != null) {
+    const maxVal = +field.max;
+    schema = schema.refine(
+      isNullOr((n) => n <= maxVal),
+      { message: `${field.caption} must be ≤ ${maxVal}` },
+    );
+  }
 
-	// 4) Max check (if configured)
-	if (field.max != null) {
-		const maxVal = +field.max;
-		schema = schema.refine(
-			isNullOr((n) => n <= maxVal),
-			{ message: `${field.caption} must be ≤ ${maxVal}` }
-		);
-	}
-
-
-	return {
-		schema,
-		input: <NumberFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} min={field.min ?? undefined} max={field.max ?? undefined} />
-	}
-}
-
+  return {
+    schema,
+    input: (
+      <NumberFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+        min={field.min ?? undefined}
+        max={field.max ?? undefined}
+      />
+    ),
+  };
+};
 
 const getDateTime = (field: Field): FieldDetails => {
+  // 1. Preprocess empty → null; strings → Dayjs
+  let schema: z.ZodTypeAny = z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    if (typeof value === "string") {
+      // try to parse
+      const dt = stringToDateTime(value);
+      return dt ?? value;
+    }
+    return value;
+  }, z.any().nullable());
 
-	// 1. Preprocess empty → null; strings → Dayjs
-	let schema: z.ZodTypeAny = z.preprocess((value) => {
-		if (value === null || value === undefined || value === "") {
-			return null;
-		}
-		if (typeof value === "string") {
-			// try to parse
-			const dt = stringToDateTime(value);
-			return dt ?? value;
-		}
-		return value;
-	}, z.any().nullable());
+  // 2. “Required?” check
+  if (field.required) {
+    schema = schema.refine((val) => val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
-	// 2. “Required?” check
-	if (field.required) {
-		schema = schema.refine((val) => val !== null, {
-			message: `${field.caption} is required`,
-		});
-	}
+  // Helper: only run a test if there’s actually a date
+  const isNullOr = (fn: (d: Dayjs) => boolean) => (val: Dayjs | null) =>
+    val === null || fn(val);
 
-	// Helper: only run a test if there’s actually a date
-	const isNullOr = (fn: (d: Dayjs) => boolean) =>
-		(val: Dayjs | null) => val === null || fn(val);
+  let min: Dayjs | undefined = undefined;
+  let max: Dayjs | undefined = undefined;
 
-	let min: Dayjs | undefined = undefined;
-	let max: Dayjs | undefined = undefined;
+  // 3. Min-date check
+  if (field.min) {
+    min = stringToDateTime(field.min)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isBefore(min)),
+      { message: `${field.caption} must be ≥ ${field.min}` },
+    );
+  }
 
-	// 3. Min-date check
-	if (field.min) {
-		min = stringToDateTime(field.min)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isBefore(min)),
-			{ message: `${field.caption} must be ≥ ${field.min}` }
-		);
-	}
+  // 4. Max-date check
+  if (field.max) {
+    max = stringToDateTime(field.max)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isAfter(max)),
+      { message: `${field.caption} must be ≤ ${field.max}` },
+    );
+  }
 
-	// 4. Max-date check
-	if (field.max) {
-		max = stringToDateTime(field.max)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isAfter(max)),
-			{ message: `${field.caption} must be ≤ ${field.max}` }
-		);
-	}
+  schema = schema.transform((val) => dateTimeToStringPrecision(val));
 
-	schema = schema.transform((val) => dateTimeToStringPrecision(val));
-
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? stringToDateTime(field.defaultValue) : undefined,
-		convertFromRawValue: (value) => {
-			return value ? stringToDateTime(value) : undefined;
-		},
-		input: <DateTimeFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} min={min} max={max} />
-	}
-}
-
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? stringToDateTime(field.defaultValue) : undefined,
+    convertFromRawValue: (value) => {
+      return value ? stringToDateTime(value) : undefined;
+    },
+    input: (
+      <DateTimeFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+        min={min}
+        max={max}
+      />
+    ),
+  };
+};
 
 const getDate = (field: Field): FieldDetails => {
-	// 1. Preprocess empty → null; strings → Dayjs
-	let schema: z.ZodTypeAny = z.preprocess((value) => {
-		if (value === null || value === undefined || value === "") {
-			return null;
-		}
-		if (typeof value === "string") {
-			// try to parse
-			const dt = stringToDate(value);
-			return dt ?? value;
-		}
-		return value;
-	}, z.any().nullable());
+  // 1. Preprocess empty → null; strings → Dayjs
+  let schema: z.ZodTypeAny = z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    if (typeof value === "string") {
+      // try to parse
+      const dt = stringToDate(value);
+      return dt ?? value;
+    }
+    return value;
+  }, z.any().nullable());
 
-	// 2. “Required?” check
-	if (field.required) {
-		schema = schema.refine((val) => val !== null, {
-			message: `${field.caption} is required`,
-		});
-	}
+  // 2. “Required?” check
+  if (field.required) {
+    schema = schema.refine((val) => val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
-	// Helper: only run a test if there’s actually a date
-	const isNullOr = (fn: (d: Dayjs) => boolean) =>
-		(val: Dayjs | null) => val === null || fn(val);
+  // Helper: only run a test if there’s actually a date
+  const isNullOr = (fn: (d: Dayjs) => boolean) => (val: Dayjs | null) =>
+    val === null || fn(val);
 
-	let min: Dayjs | undefined = undefined;
-	let max: Dayjs | undefined = undefined;
+  let min: Dayjs | undefined = undefined;
+  let max: Dayjs | undefined = undefined;
 
-	// 3. Min-date check
-	if (field.min) {
-		min = stringToDate(field.min)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isBefore(min)),
-			{ message: `${field.caption} must be ≥ ${field.min}` }
-		);
-	}
+  // 3. Min-date check
+  if (field.min) {
+    min = stringToDate(field.min)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isBefore(min)),
+      { message: `${field.caption} must be ≥ ${field.min}` },
+    );
+  }
 
-	// 4. Max-date check
-	if (field.max) {
-		max = stringToDate(field.max)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isAfter(max)),
-			{ message: `${field.caption} must be ≤ ${field.max}` }
-		);
-	}
+  // 4. Max-date check
+  if (field.max) {
+    max = stringToDate(field.max)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isAfter(max)),
+      { message: `${field.caption} must be ≤ ${field.max}` },
+    );
+  }
 
-	schema = schema.transform((val) => dateToString(val));
+  schema = schema.transform((val) => dateToString(val));
 
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? stringToDate(field.defaultValue) : undefined,
-		convertFromRawValue: (value) => {
-			return value ? stringToDate(value) : undefined;
-		},
-		input: <DateFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} min={min} max={max} />
-	}
-}
-
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? stringToDate(field.defaultValue) : undefined,
+    convertFromRawValue: (value) => {
+      return value ? stringToDate(value) : undefined;
+    },
+    input: (
+      <DateFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+        min={min}
+        max={max}
+      />
+    ),
+  };
+};
 
 const getTime = (field: Field): FieldDetails => {
-	// 1. Preprocess empty → null; strings → Dayjs
-	let schema: z.ZodTypeAny = z.preprocess((value) => {
-		if (value === null || value === undefined || value === "") {
-			return null;
-		}
-		if (typeof value === "string") {
-			// try to parse
-			const dt = stringToTime(value);
-			return dt ?? value;
-		}
-		return value;
-	}, z.any().nullable());
+  // 1. Preprocess empty → null; strings → Dayjs
+  let schema: z.ZodTypeAny = z.preprocess((value) => {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+    if (typeof value === "string") {
+      // try to parse
+      const dt = stringToTime(value);
+      return dt ?? value;
+    }
+    return value;
+  }, z.any().nullable());
 
-	// 2. “Required?” check
-	if (field.required) {
-		schema = schema.refine((val) => val !== null, {
-			message: `${field.caption} is required`,
-		});
-	}
+  // 2. “Required?” check
+  if (field.required) {
+    schema = schema.refine((val) => val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
-	// Helper: only run a test if there’s actually a date
-	const isNullOr = (fn: (d: Dayjs) => boolean) =>
-		(val: Dayjs | null) => val === null || fn(val);
+  // Helper: only run a test if there’s actually a date
+  const isNullOr = (fn: (d: Dayjs) => boolean) => (val: Dayjs | null) =>
+    val === null || fn(val);
 
-	let min: Dayjs | undefined = undefined;
-	let max: Dayjs | undefined = undefined;
+  let min: Dayjs | undefined = undefined;
+  let max: Dayjs | undefined = undefined;
 
-	// 3. Min-date check
-	if (field.min) {
-		min = stringToTime(field.min)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isBefore(min)),
-			{ message: `${field.caption} must be ≥ ${field.min}` }
-		);
-	}
+  // 3. Min-date check
+  if (field.min) {
+    min = stringToTime(field.min)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isBefore(min)),
+      { message: `${field.caption} must be ≥ ${field.min}` },
+    );
+  }
 
-	// 4. Max-date check
-	if (field.max) {
-		max = stringToTime(field.max)!;
-		schema = schema.refine(
-			isNullOr((d) => !d.isAfter(max)),
-			{ message: `${field.caption} must be ≤ ${field.max}` }
-		);
-	}
+  // 4. Max-date check
+  if (field.max) {
+    max = stringToTime(field.max)!;
+    schema = schema.refine(
+      isNullOr((d) => !d.isAfter(max)),
+      { message: `${field.caption} must be ≤ ${field.max}` },
+    );
+  }
 
-	schema = schema.transform((val) => timeToStringPrecision(val));
+  schema = schema.transform((val) => timeToStringPrecision(val));
 
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? stringToTime(field.defaultValue) : undefined,
-		convertFromRawValue: (value) => {
-			return value ? stringToTime(value) : undefined;
-		},
-		input: <TimeFormField key={field.name} name={field.name} label={field.caption} required={field.required ?? false} min={min} max={max} />
-	}
-}
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? stringToTime(field.defaultValue) : undefined,
+    convertFromRawValue: (value) => {
+      return value ? stringToTime(value) : undefined;
+    },
+    input: (
+      <TimeFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        required={field.required ?? false}
+        min={min}
+        max={max}
+      />
+    ),
+  };
+};
 
 const getBoolean = (field: Field): FieldDetails => {
-	const baseSchema = z.boolean();
+  const baseSchema = z.boolean();
 
-	let schema;
-	if (field.required) {
-		schema = baseSchema.refine(
-			(data) => data !== undefined,
-			{ message: `${field.caption} is required` }
-		);
-	} else {
-		schema = baseSchema.optional();
-	}
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? !!field.defaultValue : undefined,
-		convertFromRawValue: (value) => {
-			return value ? !!value : undefined;
-		},
-		input: <BooleanSelectFormField key={field.name} name={field.name} label={field.caption} />
-	}
-}
-
+  let schema;
+  if (field.required) {
+    schema = baseSchema.refine((data) => data !== undefined, {
+      message: `${field.caption} is required`,
+    });
+  } else {
+    schema = baseSchema.optional();
+  }
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? !!field.defaultValue : undefined,
+    convertFromRawValue: (value) => {
+      return value ? !!value : undefined;
+    },
+    input: (
+      <BooleanSelectFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+      />
+    ),
+  };
+};
 
 const getJson = (field: Field): FieldDetails => {
+  let schema: z.ZodTypeAny = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? "",
+        z.string().min(1, `${field.caption} is required`),
+      );
+    }
+    return z
+      .string()
+      .transform((i) => i?.trim() || undefined)
+      .optional()
+      .nullish();
+  })();
 
-	let schema: z.ZodTypeAny = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? '',
-				z.string().min(1, `${field.caption} is required`)
-			);
-		}
-		return z.string().transform((i) => i?.trim() || undefined).optional().nullish();
-	})();
+  // 2) If required, ban empty/null
+  if (field.required) {
+    schema = schema.refine((val) => val !== undefined && val !== null, {
+      message: `${field.caption} is required`,
+    });
+  }
 
+  // 3) JSON‐validity only if there is a value
+  schema = schema
+    .refine((val) => val === undefined || val === null || isJsonOrNull(val), {
+      message: `${field.caption} must be valid JSON`,
+    })
+    .transform((val) => (toJsonOrNull(val) ? JSON.parse(val) : undefined));
 
-	// 2) If required, ban empty/null
-	if (field.required) {
-		schema = schema.refine(
-			(val) => val !== undefined && val !== null,
-			{ message: `${field.caption} is required` }
-		);
-	}
-
-	// 3) JSON‐validity only if there is a value
-	schema = schema.refine(
-		(val) => val === undefined || val === null || isJsonOrNull(val),
-		{ message: `${field.caption} must be valid JSON` }
-	).transform((val) => toJsonOrNull(val) ? JSON.parse(val) : undefined);
-
-	return {
-		schema,
-		convertFromRawValue: (value) => {
-			if (typeof value === 'string') {
-				return value;
-			}
-			return value ? JSON.stringify(value) : undefined;
-		},
-		input: <JSONFormField key={field.name} name={field.name} label={field.caption} />
-	}
-}
+  return {
+    schema,
+    convertFromRawValue: (value) => {
+      if (typeof value === "string") {
+        return value;
+      }
+      return value ? JSON.stringify(value) : undefined;
+    },
+    input: (
+      <JSONFormField key={field.name} name={field.name} label={field.caption} />
+    ),
+  };
+};
 
 const getSingleChoice = (field: Field): FieldDetails => {
+  let schema = field.required
+    ? z
+        .any()
+        .refine((val) => !!val, { message: `${field.caption} is required` })
+    : z.string().optional().nullable();
 
-	let schema = field.required
-		? z.any().refine((val) => !!val, { message: `${field.caption} is required` })
-		: z.string().optional().nullable();
+  const options =
+    field.acceptedValues
+      ?.filter((i) => i)
+      .map((i: string | null) => ({
+        label: i!,
+        value: i!,
+      })) ?? [];
 
-	const options = field.acceptedValues?.filter(i => i)
-		.map((i: string | null) => ({
-			label: i!,
-			value: i!
-		})) ?? [];
-
-	return {
-		schema,
-		input: <SingleChoiceFormField key={field.name} name={field.name} label={field.caption} options={options} />
-	}
-}
-
+  return {
+    schema,
+    input: (
+      <SingleChoiceFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        options={options}
+      />
+    ),
+  };
+};
 
 const getMultiChoice = (field: Field): FieldDetails => {
+  // let schema = field.required
+  //     ? z.any().refine((val) => !!val && val.length, { message: `${field.caption} is required` })
+  //     : z.string().optional().nullable();
 
-	// let schema = field.required
-	//     ? z.any().refine((val) => !!val && val.length, { message: `${field.caption} is required` })
-	//     : z.string().optional().nullable();
+  const schema = (() => {
+    if (field.required) {
+      return z.preprocess(
+        (i) => i ?? [],
+        z.array(z.string()).min(1, `${field.caption} is required`),
+      );
+    }
+    return z.array(z.string()).optional().nullish();
+  })();
 
+  const options =
+    field.acceptedValues
+      ?.filter((i) => i)
+      .map((i: string | null) => ({
+        label: i!,
+        value: i!,
+      })) ?? [];
 
-	const schema = (() => {
-		if (field.required) {
-			return z.preprocess(i => i ?? [],
-				z.array(z.string()).min(1, `${field.caption} is required`)
-			);
-		}
-		return z.array(z.string()).optional().nullish();
-	})();
-
-	const options = field.acceptedValues?.filter(i => i)
-		.map((i: string | null) => ({
-			label: i!,
-			value: i!
-		})) ?? [];
-
-	return {
-		schema,
-		//defaultValue: field.defaultValue ? JSON.parse(field.defaultValue) : undefined,
-		convertFromRawValue: (value) => {
-			if (Array.isArray(value)) {
-				return value;
-			}
-			return value ? JSON.parse(value) : undefined;
-		},
-		input: <MultipleChoiceFormField key={field.name} name={field.name} label={field.caption} options={options} />
-	}
-}
+  return {
+    schema,
+    //defaultValue: field.defaultValue ? JSON.parse(field.defaultValue) : undefined,
+    convertFromRawValue: (value) => {
+      if (Array.isArray(value)) {
+        return value;
+      }
+      return value ? JSON.parse(value) : undefined;
+    },
+    input: (
+      <MultipleChoiceFormField
+        key={field.name}
+        name={field.name}
+        label={field.caption}
+        options={options}
+      />
+    ),
+  };
+};
 
 const getRelationOne = (entityName: string, edge: Edge): FieldDetails => {
+  let schema: z.ZodTypeAny = edge.required
+    ? z
+        .any()
+        .refine((val): val is Record<string, unknown> => !val, {
+          message: `${edge.caption} is required`,
+        })
+    : z.any().optional().nullable();
 
-	let schema: z.ZodTypeAny = edge.required
-		? z.any().refine((val): val is Record<string, unknown> => !val,
-			{ message: `${edge.caption} is required` }
-		)
-		: z.any().optional().nullable();
+  schema = schema.transform((val?: Option<string, OptionTagOne>) => {
+    if (!val) {
+      return undefined;
+    }
 
-	schema = schema.transform((val?: Option<string, OptionTagOne>) => {
+    if (!val.tag) {
+      return undefined;
+    }
 
-		if (!val) {
-			return undefined;
-		}
+    switch (val.tag) {
+      case "create":
+        return {
+          create: val.value,
+        };
+      case "connect":
+        return {
+          connect: {
+            id: val.value,
+          },
+        };
+      case "unset":
+        return {
+          unset: true,
+        };
+    }
+  });
 
-		if (!val.tag) {
-			return undefined;
-		}
-
-		switch (val.tag) {
-			case 'create':
-				return {
-					create: val.value
-				}
-			case 'connect':
-				return {
-					connect: {
-						id: val.value
-					}
-				}
-			case 'unset':
-				return {
-					unset: true
-				}
-		}
-
-	});
-
-	return {
-		schema,
-		convertFromRawValue: (val) => undefined,
-		input: <LookupOneFIELDFormField key={edge.name} name={edge.name} label={edge.caption} entityName={entityName} edge={edge} />
-	}
-}
+  return {
+    schema,
+    convertFromRawValue: (val) => undefined,
+    input: (
+      <LookupOneFIELDFormField
+        key={edge.name}
+        name={edge.name}
+        label={edge.caption}
+        entityName={entityName}
+        edge={edge}
+      />
+    ),
+  };
+};
 
 const getRelationMany = (entityName: string, edge: Edge): FieldDetails => {
-	let schema: z.ZodTypeAny = edge.required
-		? z.any().refine((val): val is Record<string, unknown> => !val,
-			{ message: `${edge.caption} is required` }
-		)
-		: z.any().optional().nullable();
+  let schema: z.ZodTypeAny = edge.required
+    ? z
+        .any()
+        .refine((val): val is Record<string, unknown> => !val, {
+          message: `${edge.caption} is required`,
+        })
+    : z.any().optional().nullable();
 
-	schema = schema.transform((val?: Options<string, OptionTagMany>) => {
+  schema = schema.transform((val?: Options<string, OptionTagMany>) => {
+    if (!val) {
+      return undefined;
+    }
 
-		if (!val) {
-			return undefined;
-		}
+    return {
+      connect: val
+        .filter((i) => i.tag == "connect")
+        .map((i) => ({
+          id: i.value,
+        })),
+      create: val.filter((i) => i.tag == "create").map((i) => i.value),
+      disconnect: val
+        .filter((i) => i.tag == "disconnect")
+        .map((i) => ({
+          id: i.value,
+        })),
+    };
+  });
 
-		return {
-			connect: val.filter(i => i.tag == 'connect')
-				.map(i => ({
-					id: i.value
-				})),
-			create: val.filter(i => i.tag == 'create')
-				.map(i => i.value),
-			disconnect: val.filter(i => i.tag == 'disconnect')
-				.map(i => ({
-					id: i.value
-				}))
-		}
-	});
-
-	return {
-		schema,
-		convertFromRawValue: (val) => undefined,
-		input: <LookupManyFIELDFormField key={edge.name} name={edge.name} label={edge.caption} entityName={entityName} edge={edge} />
-	}
-}
+  return {
+    schema,
+    convertFromRawValue: (val) => undefined,
+    input: (
+      <LookupManyFIELDFormField
+        key={edge.name}
+        name={edge.name}
+        label={edge.caption}
+        entityName={entityName}
+        edge={edge}
+      />
+    ),
+  };
+};
 
 const getFormField = (field: Field): FieldDetails => {
-	switch (field.type) {
-		case "ShortText": return getShortText(field);
-		case "LongText": return getLongText(field);
-		case "RichText": return getRichText(field);
-		case "Email": return getEmail(field);
-		case "Integer": return getNumber(field);
-		case "Decimal": return getNumber(field);
-		case "Float": return getNumber(field);
-		case "DateTime": return getDateTime(field);
-		case "Date": return getDate(field);
-		case "Time": return getTime(field);
-		case "Media": return getShortText(field);
-		case "Boolean": return getBoolean(field);
-		case "Json": return getJson(field);
-		case "SingleChoice": return getSingleChoice(field);
-		case "MultipleChoice": return getMultiChoice(field);
-		default: return getShortText(field);
-	}
-}
+  switch (field.type) {
+    case "ShortText":
+      return getShortText(field);
+    case "LongText":
+      return getLongText(field);
+    case "RichText":
+      return getRichText(field);
+    case "Markdown":
+      return getMarkdown(field);
+    case "Email":
+      return getEmail(field);
+    case "Integer":
+      return getNumber(field);
+    case "Decimal":
+      return getNumber(field);
+    case "Float":
+      return getNumber(field);
+    case "DateTime":
+      return getDateTime(field);
+    case "Date":
+      return getDate(field);
+    case "Time":
+      return getTime(field);
+    case "Media":
+      return getShortText(field);
+    case "Boolean":
+      return getBoolean(field);
+    case "Json":
+      return getJson(field);
+    case "SingleChoice":
+      return getSingleChoice(field);
+    case "MultipleChoice":
+      return getMultiChoice(field);
+    default:
+      return getShortText(field);
+  }
+};
 
 const getFormEdge = (entityName: string, edge: Edge): FieldDetails => {
-	switch (edge.relationType) {
-		case RelationType.One:
-		case RelationType.OneToOne:
-		case RelationType.OneToMany:
-			return getRelationOne(entityName, edge);
+  switch (edge.relationType) {
+    case RelationType.One:
+    case RelationType.OneToOne:
+    case RelationType.OneToMany:
+      return getRelationOne(entityName, edge);
 
-		case RelationType.Many:
-		case RelationType.ManyToOne:
-		case RelationType.ManyToMany:
-			return getRelationMany(entityName, edge);
+    case RelationType.Many:
+    case RelationType.ManyToOne:
+    case RelationType.ManyToMany:
+      return getRelationMany(entityName, edge);
 
-		default:
-			return {
-				schema: z.any().nullable(),
-				input: <>Unknown Relation</>
-			}
-	}
-
-}
-
+    default:
+      return {
+        schema: z.any().nullable(),
+        input: <>Unknown Relation</>,
+      };
+  }
+};
 
 export const useContentManagerFormSchema = (entity: FullEntity | null) => {
+  const fieldsDescriptors = useMemo(() => {
+    if (!entity) {
+      return [];
+    }
 
-	const fieldsDescriptors = useMemo(() => {
-		if (!entity) {
-			return [];
-		}
+    const fields = entity
+      .fields!.filter((i) => i.name != "id") // skip id
+      .filter((i) => i.name != "createdAt" && i.name != "updatedAt") // TODO: skip createdAt, updateAt from form schema
+      .map((field) => ({
+        ...getFormField(field),
+        name: field.name,
+        field,
+      }));
 
-		const fields = entity.fields!
-			.filter(i => i.name != 'id') // skip id
-			.filter(i => i.name != 'createdAt' && i.name != 'updatedAt') // TODO: skip createdAt, updateAt from form schema
-			.map((field) => ({
-				...getFormField(field),
-				name: field.name,
-				field
-			}));
+    const edges = entity
+      .edges!.filter((i) => i.name.startsWith("ref") == false) //TODO: ref fields will be removed from BE
+      .filter((i) => i.name != "createdBy" && i.name != "updatedBy") // skip createdBy, updatedBy from form schema
+      .map((edge) => ({
+        ...getFormEdge(entity.name, edge),
+        name: edge.name,
+        edge,
+      }));
 
-		const edges = entity.edges!
-			.filter(i => i.name.startsWith('ref') == false) //TODO: ref fields will be removed from BE
-			.filter(i => i.name != 'createdBy' && i.name != 'updatedBy') // skip createdBy, updatedBy from form schema
-			.map((edge) => ({
-				...getFormEdge(entity.name, edge),
-				name: edge.name,
-				edge
-			}));
+    return [...fields, ...edges];
+  }, [entity]);
 
-		return [
-			...fields,
-			...edges
-		]
+  const schema = useMemo(() => {
+    const fieldsSchema = fieldsDescriptors.reduce(
+      (acc: any, field) => {
+        acc = {
+          ...acc,
+          [field.name]: field.schema,
+        };
+        return acc;
+      },
+      {} as Record<string, z.ZodTypeAny>,
+    );
 
-	}, [entity]);
+    return z.object(fieldsSchema);
+  }, [fieldsDescriptors]);
 
-	const schema = useMemo(() => {
-		const fieldsSchema = fieldsDescriptors.reduce((acc: any, field) => {
-			acc = {
-				...acc,
-				[field.name]: field.schema
-			}
-			return acc;
-		}, {} as Record<string, z.ZodTypeAny>);
+  const fields = useMemo(() => {
+    return fieldsDescriptors.map((field) => field.input);
+  }, [fieldsDescriptors]);
 
-		return z.object(fieldsSchema);
-	}, [fieldsDescriptors]);
+  const schemaDefaultValue = useMemo(() => {
+    return entity?.fields.reduce((acc: any, field) => {
+      if (field.defaultValue) {
+        acc[field.name] = field.defaultValue;
+      }
+      return acc;
+    }, {});
+  }, [entity?.fields]);
 
-	const fields = useMemo(() => {
-		return fieldsDescriptors.map(field => field.input);
-	}, [fieldsDescriptors]);
+  const convertFromRawValue = useCallback((defaultValue: any) => {
+    if (!defaultValue) {
+      return defaultValue;
+    }
 
-	const schemaDefaultValue = useMemo(() => {
-		return entity?.fields.reduce((acc: any, field) => {
-			if (field.defaultValue) {
-				acc[field.name] = field.defaultValue;
-			}
-			return acc;
-		}, {});
-	}, [entity?.fields]);
+    const keys = Object.keys(defaultValue);
+    const result = keys.reduce((acc: any, key) => {
+      const feldDescription = fieldsDescriptors.find((i) => i.name == key);
+      const value = feldDescription?.convertFromRawValue
+        ? feldDescription?.convertFromRawValue?.(defaultValue[key])
+        : defaultValue[key];
 
-	const convertFromRawValue = useCallback((defaultValue: any) => {
-		if (!defaultValue) {
-			return defaultValue;
-		}
+      if (value == undefined || value == null) {
+        return acc;
+      }
 
-		const keys = Object.keys(defaultValue);
-		const result = keys.reduce((acc: any, key) => {
-			const feldDescription = fieldsDescriptors.find(i => i.name == key);
-			const value = feldDescription?.convertFromRawValue ? feldDescription?.convertFromRawValue?.(defaultValue[key]) : defaultValue[key];
+      acc[key] = value;
+      return acc;
+    }, {});
 
-			if (value == undefined || value == null) {
-				return acc;
-			}
+    return result;
+  }, []);
 
-			acc[key] = value;
-			return acc;
-		}, {});
+  return useMemo(
+    () => ({
+      schema,
+      fields,
+      schemaDefaultValue,
+      convertFromRawValue,
+    }),
+    [schema, fields],
+  );
+};
 
-		return result;
-	}, []);
+useContentManagerFormSchema.displayName = "useContentManagerFormSchema";
 
-	return useMemo(() => ({
-		schema,
-		fields,
-		schemaDefaultValue,
-		convertFromRawValue
-	}), [schema, fields]);
-}
+export const useGenericFiedFormSchema = () => {};
 
-useContentManagerFormSchema.displayName = 'useContentManagerFormSchema';
+export const useGenericEdgeFormSchema = (
+  entity: FullEntity | null,
+  edgeName: string,
+) => {
+  const edge = useMemo(() => {
+    if (!entity) {
+      return null;
+    }
+    return entity.edges?.find((i) => i.name === edgeName);
+  }, [entity, edgeName]);
 
+  const edgeDescriptor = useMemo(() => {
+    if (!entity) {
+      return null;
+    }
 
-export const useGenericFiedFormSchema = () => {
+    if (!edge) {
+      return null;
+    }
 
-}
+    const result = {
+      ...getFormEdge(entity.name, edge),
+      name: edge.name,
+      edge,
+    };
+    return result;
+  }, [entity, edge]);
 
-export const useGenericEdgeFormSchema = (entity: FullEntity | null, edgeName: string) => {
+  const convertFromRawValue = useCallback(
+    (defaultValue: any) => {
+      if (!edge) {
+        return null;
+      }
 
-	const edge = useMemo(() => {
-		if (!entity) {
-			return null;
-		}
-		return entity.edges?.find(i => i.name === edgeName);
-	}, [entity, edgeName]);
+      const value = edgeDescriptor?.convertFromRawValue
+        ? edgeDescriptor?.convertFromRawValue?.(defaultValue)
+        : defaultValue;
+      return value;
+    },
+    [edgeDescriptor, edge],
+  );
 
-	const edgeDescriptor = useMemo(() => {
-		if (!entity) {
-			return null;
-		}
+  const field = useMemo((): ReactNode => {
+    if (!edgeDescriptor) {
+      return <></>;
+    }
 
-		if (!edge) {
-			return null;
-		}
+    return edgeDescriptor.input;
+  }, [edgeDescriptor]);
 
-		const result = {
-			...getFormEdge(entity.name, edge),
-			name: edge.name,
-			edge
-		};
-		return result;
-	}, [entity, edge]);
+  const schema = useMemo(() => {
+    if (!edgeDescriptor) {
+      return z.any();
+    }
 
-	const convertFromRawValue = useCallback((defaultValue: any) => {
+    return edgeDescriptor.schema;
+  }, [edgeDescriptor]);
 
-		if (!edge) {
-			return null;
-		}
-
-		const value = edgeDescriptor?.convertFromRawValue ? edgeDescriptor?.convertFromRawValue?.(defaultValue) : defaultValue;
-		return value;
-	}, [edgeDescriptor, edge]);
-
-	const field = useMemo(():ReactNode => {
-		if (!edgeDescriptor) {
-			return <></>;
-		}
-
-		return edgeDescriptor.input;
-	}, [edgeDescriptor]);
-
-	const schema = useMemo(() => {
-		if (!edgeDescriptor) {
-			return z.any();
-		}
-
-		return edgeDescriptor.schema;
-	}, [edgeDescriptor]);
-
-	return useMemo(() => ({
-		edgeDescriptor,
-		convertFromRawValue,
-		field,
-		schema
-	}), [edgeDescriptor, convertFromRawValue, field, schema]);
-}
+  return useMemo(
+    () => ({
+      edgeDescriptor,
+      convertFromRawValue,
+      field,
+      schema,
+    }),
+    [edgeDescriptor, convertFromRawValue, field, schema],
+  );
+};

--- a/src/admin/src/hooks/use-dynamic-grid-columns.tsx
+++ b/src/admin/src/hooks/use-dynamic-grid-columns.tsx
@@ -1,309 +1,470 @@
-import dayjs from 'dayjs';
-import { MutableRefObject, ReactNode, useMemo, useRef } from 'react';
-import { ApiFieldTypes, FormFieldTypes } from '@/types/field-type-descriptor';
-import { localeConfig } from "@/config/locale-config"
-import CheckIcon from '@mui/icons-material/Check';
-import { ColumnDef, useResponsivePin, useRowExpansionStore } from 'mosaic-data-table';
-import { Edge, Field, RelationType } from '@/lib/apollo/graphql.entities';
-import { Avatar, Button, Chip, Stack, Typography } from '@mui/material';
+import dayjs from "dayjs";
+import { MutableRefObject, ReactNode, useMemo, useRef } from "react";
+import { ApiFieldTypes, FormFieldTypes } from "@/types/field-type-descriptor";
+import { localeConfig } from "@/config/locale-config";
+import CheckIcon from "@mui/icons-material/Check";
+import {
+  ColumnDef,
+  useResponsivePin,
+  useRowExpansionStore,
+} from "mosaic-data-table";
+import { Edge, Field, RelationType } from "@/lib/apollo/graphql.entities";
+import { Avatar, Button, Chip, Stack, Typography } from "@mui/material";
 // import { stringAvatar } from '@/lib/utils/avatar';
-import { stringToDate, stringToDateTime, stringToTime } from '@/core-features/dynamic-form/value-convertor';
-import { InlineAvatar } from '@/shared/components/avatar';
-import { useViewRelationStore } from '@/core-features/view-item/use-view-relation-store';
+import {
+  stringToDate,
+  stringToDateTime,
+  stringToTime,
+} from "@/core-features/dynamic-form/value-convertor";
+import { InlineAvatar } from "@/shared/components/avatar";
+import { useViewRelationStore } from "@/core-features/view-item/use-view-relation-store";
 
 export type ColumnOptions = {
-    hasSort?: boolean,
-    width?: number,
-}
+  hasSort?: boolean;
+  width?: number;
+};
 
 interface UseDynamicGridColumnsProps {
-    entityName: string,
-    fields?: Field[],
-    edges?: Edge[],
-    displayFieldName?: string,
-	openRelation: (entityName: string, edge: Edge, entryId: string) => void,
-    showId: boolean
+  entityName: string;
+  fields?: Field[];
+  edges?: Edge[];
+  displayFieldName?: string;
+  openRelation: (entityName: string, edge: Edge, entryId: string) => void;
+  showId: boolean;
 }
 export const useDynamicGridColumns = ({
-    entityName,
-    fields = [],
-    edges = [],
-    displayFieldName,
-    openRelation,
-    showId
+  entityName,
+  fields = [],
+  edges = [],
+  displayFieldName,
+  openRelation,
+  showId,
 }: UseDynamicGridColumnsProps): ColumnDef[] => {
+  const displayFieldPin = useResponsivePin({
+    pin: "left",
+    breakpoint: "sm",
+    direction: "up",
+  });
 
-    const displayFieldPin = useResponsivePin({ pin: 'left', breakpoint: 'sm', direction: 'up' });
+  const expansionStoreRef = useRef(openRelation);
+  expansionStoreRef.current = openRelation;
 
-    const expansionStoreRef = useRef(openRelation);
-    expansionStoreRef.current = openRelation;
-
-    return useMemo(() => (
-        [
-            ...fields
-                .filter(i => showId ? true : i.name != 'id')
-                .filter(i => !i.private) // TODO: this should be hidden from BE
-                .filter(i => i.type != 'RichText') // TODO: set RichText based on configuration
-                .filter(i => i.type != 'Json') // TODO: set JSON based on configuration
-                .map(i => fieldToColumn(i))
-                .map(i => i.id === displayFieldName ? {
-                    ...i,
-                    pin: displayFieldPin,
-                    highlight: true
-                } : i),
-            ...edges.map(i => edgeToColumn(entityName, i, expansionStoreRef)),
-        ]
-    ), [displayFieldPin, showId, displayFieldName, fields, edges]);
-}
-
+  return useMemo(
+    () => [
+      ...fields
+        .filter((i) => (showId ? true : i.name != "id"))
+        .filter((i) => !i.private) // TODO: this should be hidden from BE
+        .filter((i) => i.type != "RichText") // TODO: set RichText based on configuration
+        .filter((i) => i.type != "Json") // TODO: set JSON based on configuration
+        .map((i) => fieldToColumn(i))
+        .map((i) =>
+          i.id === displayFieldName
+            ? {
+                ...i,
+                pin: displayFieldPin,
+                highlight: true,
+              }
+            : i,
+        ),
+      ...edges.map((i) => edgeToColumn(entityName, i, expansionStoreRef)),
+    ],
+    [displayFieldPin, showId, displayFieldName, fields, edges],
+  );
+};
 
 const fieldToColumn = (field: Field): ColumnDef<Field> => {
+  // Add avatar for name column
+  if (field.name == "name" && field.type == "ShortText") {
+    return shortTextColumnDef(
+      field.name,
+      field.caption,
+      (row: any) => {
+        const cellValue = row[field.name];
+        return (
+          <Stack direction="row" gap={1} alignItems="center">
+            <InlineAvatar name={cellValue} />
+            {cellValue}
+          </Stack>
+        );
+      },
+      {
+        width: 180,
+        hasSort: true,
+      },
+    );
+  }
 
-    // Add avatar for name column
-    if (field.name == 'name' && field.type == 'ShortText') {
-        return shortTextColumnDef(field.name, field.caption, (row: any) => {
-            const cellValue = row[field.name];
-            return (<Stack direction="row" gap={1} alignItems="center">
-                <InlineAvatar name={cellValue} />
-                {cellValue}
-            </Stack>)
-        }, {
-            width: 180,
-            hasSort: true
-        });
-    }
+  switch (field.type as ApiFieldTypes) {
+    case "ShortText":
+      return shortTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "LongText":
+      return longTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "RichText":
+      return richTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Markdown":
+      return richTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Integer":
+      return integerColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "DateTime":
+      return dateTimeColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Date":
+      return dateColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Time":
+      return timeColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "Boolean":
+      return booleanColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+    case "MultipleChoice":
+      return multiChoiceColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: false },
+      );
+    default:
+      return shortTextColumnDef(
+        field.name,
+        field.caption,
+        (row: any) => row[field.name],
+        { hasSort: true },
+      );
+  }
+};
 
-    switch (field.type as ApiFieldTypes) {
-        case 'ShortText': return shortTextColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'LongText': return longTextColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'RichText': return richTextColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'Integer': return integerColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'DateTime': return dateTimeColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'Date': return dateColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'Time': return timeColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'Boolean': return booleanColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-        case 'MultipleChoice': return multiChoiceColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: false });
-        default: return shortTextColumnDef(field.name, field.caption, (row: any) => row[field.name], { hasSort: true });
-    }
-}
+const edgeToColumn = (
+  entityName: string,
+  edge: Edge,
+  openRelation: MutableRefObject<
+    (entityName: string, edge: Edge, entryId: string) => void
+  >,
+): ColumnDef<Edge> => {
+  switch (edge.relationType) {
+    case RelationType.One:
+    case RelationType.OneToOne:
+    case RelationType.OneToMany:
+      return oneColumnDef(entityName, edge, openRelation);
+    case RelationType.Many:
+    case RelationType.ManyToOne:
+    case RelationType.ManyToMany:
+      return manyColumnDef(entityName, edge, openRelation);
+  }
 
-const edgeToColumn = (entityName: string, edge: Edge, openRelation: MutableRefObject<(entityName: string, edge: Edge, entryId: string) => void>): ColumnDef<Edge> => {
+  return {
+    id: edge.name,
+    header: "",
+    cell: (row: any) => "",
+  };
+};
 
-    switch (edge.relationType) {
-        case RelationType.One:
-        case RelationType.OneToOne:
-        case RelationType.OneToMany:
-            return oneColumnDef(entityName, edge, openRelation);
-        case RelationType.Many:
-        case RelationType.ManyToOne:
-        case RelationType.ManyToMany:
-            return manyColumnDef(entityName, edge, openRelation);
-    }
+const shortTextColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => ReactNode,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => render(row),
+    width: options?.width ?? 180,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-    return {
-        id: edge.name,
-        header: '',
-        cell: (row: any) => ''
-    }
-}
+const longTextColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => render(row),
+    width: options?.width ?? 300,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-const shortTextColumnDef = (name: string, caption: string, render: (row: any) => ReactNode, options?: ColumnOptions): ColumnDef<any> => {
+const richTextColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => render(row),
+    width: options?.width ?? 300,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => render(row),
-        width: options?.width ?? 180,
-        hasSort: options?.hasSort ?? false
-    };
-}
+const integerColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => number,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => render(row),
+    width: options?.width ?? 150,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-const longTextColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => render(row),
-        width: options?.width ?? 300,
-        hasSort: options?.hasSort ?? false
-    };
-}
+const dateTimeColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
+      if (!value) {
+        return "";
+      }
 
-const richTextColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => render(row),
-        width: options?.width ?? 300,
-        hasSort: options?.hasSort ?? false
-    };
-}
+      return (
+        stringToDateTime(value)?.format(localeConfig.dateTime.displayFormat) ??
+        undefined
+      );
+    },
+    width: options?.width ?? 210,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-const integerColumnDef = (name: string, caption: string, render: (row: any) => number, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => render(row),
-        width: options?.width ?? 150,
-        hasSort: options?.hasSort ?? false
-    };
-}
+const dateColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
+      if (!value) {
+        return "";
+      }
 
-const dateTimeColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
+      return (
+        stringToDate(value)?.format(localeConfig.date.displayFormat) ??
+        undefined
+      );
+    },
+    width: options?.width ?? 120,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-            const value = render(row);
-            if (!value) {
-                return '';
-            }
+const timeColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
+      if (!value) {
+        return "";
+      }
 
-            return stringToDateTime(value)?.format(localeConfig.dateTime.displayFormat) ?? undefined;
+      return (
+        stringToTime(value)?.format(localeConfig.time.displayFormat) ??
+        undefined
+      );
+    },
+    width: options?.width ?? 180,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-        },
-        width: options?.width ?? 210,
-        hasSort: options?.hasSort ?? false
-    };
-}
+const booleanColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
+      if (!value) {
+        return "";
+      }
 
-const dateColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
+      return <CheckIcon />;
+    },
+    width: options?.width ?? 120,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-            const value = render(row);
-            if (!value) {
-                return '';
-            }
+const multiChoiceColumnDef = (
+  name: string,
+  caption: string,
+  render: (row: any) => string,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: name,
+    header: caption,
+    cell: (row: any) => {
+      const value = render(row);
 
-            return stringToDate(value)?.format(localeConfig.date.displayFormat) ?? undefined;
+      if (!Array.isArray(value)) {
+        return value;
+      }
 
-        },
-        width: options?.width ?? 120,
-        hasSort: options?.hasSort ?? false
-    };
-}
+      return (
+        <Stack direction="row" gap="3px">
+          {value.map((i) => {
+            return <Chip key={i} label={i} size="small" variant="outlined" />;
+          })}
+        </Stack>
+      );
+    },
+    width: options?.width ?? 120,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-const timeColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
+const oneColumnDef = (
+  entityName: string,
+  edge: Edge,
+  openRelation: MutableRefObject<
+    (entityName: string, edge: Edge, entryId: string) => void
+  >,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: edge.name,
+    header: edge.caption,
+    cell: (row: any) => {
+      const entityValue = row[edge.name];
+      if (!entityValue) {
+        return "";
+      }
 
-            const value = render(row);
-            if (!value) {
-                return '';
-            }
+      const displayValue =
+        entityValue[edge.relatedEntity.displayField.name] ||
+        `Id: ${entityValue["id"]}`;
 
-            return stringToTime(value)?.format(localeConfig.time.displayFormat) ?? undefined;
+      return (
+        <Button
+          variant="text"
+          sx={{
+            padding: 0,
+          }}
+          onClick={() => {
+            openRelation.current(entityName, edge, row.id);
+          }}
+        >
+          <Typography
+            color="text.primary"
+            variant="body2"
+            sx={{ textDecoration: "underline" }}
+          >
+            {displayValue}
+          </Typography>
+        </Button>
+      );
+    },
+    width: options?.width ?? 180,
+    hasSort: options?.hasSort ?? false,
+  };
+};
 
-        },
-        width: options?.width ?? 180,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
-const booleanColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
-
-            const value = render(row);
-            if (!value) {
-                return '';
-            }
-
-            return (<CheckIcon />)
-
-        },
-        width: options?.width ?? 120,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
-const multiChoiceColumnDef = (name: string, caption: string, render: (row: any) => string, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: name,
-        header: caption,
-        cell: (row: any) => {
-
-            const value = render(row);
-
-            if (!Array.isArray(value)) {
-                return value;
-            }
-
-            return (<Stack direction="row" gap="3px">
-                {value.map((i) => {
-                    return (<Chip key={i} label={i} size="small" variant="outlined" />)
-                })}
-            </Stack>
-            )
-
-        },
-        width: options?.width ?? 120,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
-const oneColumnDef = (entityName: string, edge: Edge, openRelation: MutableRefObject<(entityName: string, edge: Edge, entryId: string) => void>, options?: ColumnOptions): ColumnDef<any> => {
-
-    return {
-        id: edge.name,
-        header: edge.caption,
-        cell: (row: any) => {
-            const entityValue = row[edge.name];
-            if (!entityValue) {
-                return '';
-            }
-
-            const displayValue = entityValue[edge.relatedEntity.displayField.name] || `Id: ${entityValue['id']}`;
-
-            return <Button
-                variant="text"
-                sx={{
-                    padding: 0
-                }}
-                onClick={() => {
-					openRelation.current(entityName, edge, row.id);
-                }}>
-                <Typography
-                    color="text.primary"
-                    variant='body2'
-                    sx={{ textDecoration: 'underline' }}>{displayValue}</Typography></Button>
-        },
-        width: options?.width ?? 180,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
-const manyColumnDef = (entityName: string, edge: Edge, openRelation: MutableRefObject<(entityName: string, edge: Edge, entryId: string) => void>, options?: ColumnOptions): ColumnDef<any> => {
-    return {
-        id: edge.name,
-        header: edge.caption,
-        cell: (row: any) => {
-
-            return <Button
-                variant="text"
-                sx={{
-                    padding: 0
-                }}
-                onClick={() => {
-
-					openRelation.current(entityName, edge, row.id);
-
-                }}>
-                <Typography
-                    color="text.primary"
-                    variant='body2'
-                    sx={{ textDecoration: 'underline' }}>VIEW</Typography>
-            </Button>
-        },
-        width: options?.width ?? 180,
-        hasSort: options?.hasSort ?? false
-    };
-}
-
+const manyColumnDef = (
+  entityName: string,
+  edge: Edge,
+  openRelation: MutableRefObject<
+    (entityName: string, edge: Edge, entryId: string) => void
+  >,
+  options?: ColumnOptions,
+): ColumnDef<any> => {
+  return {
+    id: edge.name,
+    header: edge.caption,
+    cell: (row: any) => {
+      return (
+        <Button
+          variant="text"
+          sx={{
+            padding: 0,
+          }}
+          onClick={() => {
+            openRelation.current(entityName, edge, row.id);
+          }}
+        >
+          <Typography
+            color="text.primary"
+            variant="body2"
+            sx={{ textDecoration: "underline" }}
+          >
+            VIEW
+          </Typography>
+        </Button>
+      );
+    },
+    width: options?.width ?? 180,
+    hasSort: options?.hasSort ?? false,
+  };
+};

--- a/src/admin/src/shared/components/markdown-editor.tsx
+++ b/src/admin/src/shared/components/markdown-editor.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { Box, InputBaseComponentProps } from "@mui/material";
+import MDEditor from "@uiw/react-md-editor";
+import { forwardRef, useImperativeHandle } from "react";
+
+export const MarkdownEditor = forwardRef(function MarkdownEditor(
+  props: InputBaseComponentProps,
+  ref,
+) {
+  const { name, value, onChange } = props;
+
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      /* no-op */
+    },
+  }));
+
+  return (
+    <Box width={1} sx={{ overflow: "visible" }}>
+      <MDEditor
+        value={(value as string) ?? ""}
+        onChange={(val) => {
+          onChange?.({ target: { name, value: val || "" } } as any);
+        }}
+      />
+    </Box>
+  );
+});
+
+MarkdownEditor.displayName = "MarkdownEditor";

--- a/src/admin/src/types/field-type-descriptor.ts
+++ b/src/admin/src/types/field-type-descriptor.ts
@@ -1,7 +1,51 @@
 import { FC, ReactNode } from "react";
 
-export type FieldScalarTypes = 'ID' | 'ShortText' | 'LongText' | 'Email' | 'RichText' | 'Password' | 'Integer' | 'Decimal' | 'Float' | 'DateTime' | 'Date' | 'Time' | 'media' | 'Boolean' | 'Json' | 'Enum' | 'SingleChoice' | 'MultipleChoice';
-export type EdgeRelationTypes = 'Relation';
+export type FieldScalarTypes =
+  | "ID"
+  | "ShortText"
+  | "LongText"
+  | "Email"
+  | "RichText"
+  | "Markdown"
+  | "Password"
+  | "Integer"
+  | "Decimal"
+  | "Float"
+  | "DateTime"
+  | "Date"
+  | "Time"
+  | "media"
+  | "Boolean"
+  | "Json"
+  | "Enum"
+  | "SingleChoice"
+  | "MultipleChoice";
+export type EdgeRelationTypes = "Relation";
 export type ApiFieldTypes = FieldScalarTypes | EdgeRelationTypes;
 
-export type FormFieldTypes = 'ShortText' | 'LongText' | 'RichText' | 'Password' | 'Number' | 'Boolean' | 'BooleanSelect' | 'DateTime' | 'Date' | 'Time' | 'Json' | 'Select' | 'TagsSelect' | 'SingleChoice' | 'MultipleChoice' | 'RelationOne' | 'RelationMany' | 'Select' | 'TagsSelect' | 'BooleanSelect' | 'Autocomplete' | 'EntitySelector' | 'RelationOne' | 'RelationMany';
+export type FormFieldTypes =
+  | "ShortText"
+  | "LongText"
+  | "RichText"
+  | "Markdown"
+  | "Password"
+  | "Number"
+  | "Boolean"
+  | "BooleanSelect"
+  | "DateTime"
+  | "Date"
+  | "Time"
+  | "Json"
+  | "Select"
+  | "TagsSelect"
+  | "SingleChoice"
+  | "MultipleChoice"
+  | "RelationOne"
+  | "RelationMany"
+  | "Select"
+  | "TagsSelect"
+  | "BooleanSelect"
+  | "Autocomplete"
+  | "EntitySelector"
+  | "RelationOne"
+  | "RelationMany";

--- a/src/api/entgql/domain/svc/markdown_test.go
+++ b/src/api/entgql/domain/svc/markdown_test.go
@@ -1,0 +1,13 @@
+package svc_test
+
+import (
+	"testing"
+
+	"github.com/GoLabra/labra/src/api/entgql/entity"
+	. "github.com/onsi/gomega"
+)
+
+func TestMarkdownFieldType(t *testing.T) {
+	RegisterTestingT(t)
+	Expect(string(entity.FieldTypeMarkdown)).To(Equal("Markdown"))
+}

--- a/src/api/entgql/entity/field.go
+++ b/src/api/entgql/entity/field.go
@@ -98,6 +98,7 @@ const (
 	FieldTypeShortText      FieldType = "ShortText"
 	FieldTypeLongText       FieldType = "LongText"
 	FieldTypeRichText       FieldType = "RichText"
+	FieldTypeMarkdown       FieldType = "Markdown"
 	FieldTypeFileContent    FieldType = "FileContent"
 	FieldTypeEmail          FieldType = "Email"
 	FieldTypeInteger        FieldType = "Integer"

--- a/src/api/entgql/generator/generator.go
+++ b/src/api/entgql/generator/generator.go
@@ -204,6 +204,8 @@ func Imports(fields []entity.Field) map[string]bool {
 			imports["entgo.io/ent/dialect"] = true
 		case entity.FieldTypeRichText:
 			imports["entgo.io/ent/dialect"] = true
+		case entity.FieldTypeMarkdown:
+			imports["entgo.io/ent/dialect"] = true
 		case entity.FieldTypeEmail:
 		case entity.FieldTypeInteger:
 		case entity.FieldTypeDecimal:

--- a/src/api/entgql/templates/entschema/entity.go.tmpl
+++ b/src/api/entgql/templates/entschema/entity.go.tmpl
@@ -49,6 +49,8 @@ func ({{$.Entity.EntName}}) Fields() []ent.Field {
             {{template "LongText" $f}}
         {{- else if eq $f.Type "RichText" }}
             {{template "RichText" $f}}
+        {{- else if eq $f.Type "Markdown" }}
+            {{template "Markdown" $f}}
         {{- else if eq $f.Type "Email" }}
             {{template "Email" $f}}
         {{- else if eq $f.Type "Integer" }}

--- a/src/api/entgql/templates/entschema/markdown.go.tmpl
+++ b/src/api/entgql/templates/entschema/markdown.go.tmpl
@@ -1,0 +1,21 @@
+{{- define "Markdown"}}
+                field.String("{{$.EntName}}").
+                        {{- if $.Required | IsFalse  }}
+                        Optional().
+            Nillable().
+                        {{- end}}
+                        SchemaType(map[string]string{
+                                dialect.MySQL:    "MEDIUMTEXT",
+                                dialect.Postgres: "TEXT",
+                        }).
+                        Annotations(
+                                entgql.OrderField("{{$.EntName | CamelCase}}"),
+                                annotations.Field{
+                                        Caption:   "{{$.Caption}}",
+                                        Type: entity.FieldTypeMarkdown,
+                                        {{- if $.Private }}
+                                        Private: {{$.Private}},
+                                        {{- end }}
+                                },
+                        ),
+{{- end}}


### PR DESCRIPTION
## Summary
- add Markdown field type to entity model and code generator
- generate Markdown fields in ent schema templates
- support Markdown editing in admin UI via new MarkdownEditor
- map Markdown form field and grid column
- include basic tests verifying Markdown constant

## Testing
- `go test ./...` *(fails: Unexpected call to Generate)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e963b5094832ca11edb5acad032cc