### PR TITLE
Token Revocation and Logout Enforcement

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/caarlos0/env/v6"
 	"github.com/joho/godotenv"
@@ -35,6 +36,9 @@ type Config struct {
 	AuthLoginRateLimitRPM  int `env:"AUTH_LOGIN_RATE_LIMIT_RPM" envDefault:"10"`
 	AuthSignupRateLimitRPM int `env:"AUTH_SIGNUP_RATE_LIMIT_RPM" envDefault:"5"`
 	AuthAPIRateLimitRPM    int `env:"AUTH_API_RATE_LIMIT_RPM" envDefault:"100"`
+
+	AccessTokenTTL  time.Duration `env:"ACCESS_TOKEN_TTL" envDefault:"15m"`
+	RefreshTokenTTL time.Duration `env:"REFRESH_TOKEN_TTL" envDefault:"168h"`
 }
 
 // Secrets holds sensitive credentials fetched from Infisical or environment variables.

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -55,6 +55,8 @@ const (
 	ServiceContextValue             ContextKey = "service"
 	AdminRepositoryContextValue     ContextKey = "adminRepository"
 	AdminServiceContextValue        ContextKey = "adminService"
+	AdminEntClientContextValue      ContextKey = "adminEntClient"
+	EntClientContextValue           ContextKey = "entClient"
 	CentrifugeClientContextValue    ContextKey = "centrifugeClient"
 	UserContextValue                ContextKey = "user"
 	RoleContextValue                ContextKey = "role"

--- a/entgql/domain/repo/repository.go
+++ b/entgql/domain/repo/repository.go
@@ -25,6 +25,7 @@ type Txer interface {
 }
 
 type Repository struct {
+	Client *ent.Client
 	// Node                  repo.Node
 	Tx         Txer
 	Permission repo.Permission
@@ -36,6 +37,7 @@ type Repository struct {
 
 func New(client *ent.Client) *Repository {
 	return &Repository{
+		Client: client,
 		// Node:                  NewNode(client),
 		Tx:         NewTx(client),
 		Permission: NewPermission(client),

--- a/entgql/domain/svc/admin_user.go
+++ b/entgql/domain/svc/admin_user.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GoLabra/labra/entgql/domain/repo"
 	"github.com/GoLabra/labra/entgql/ent"
+	"github.com/GoLabra/labra/jwtrefresh"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -40,6 +41,25 @@ func hashPasswordAdminUserCreate(data *ent.CreateAdminUserInput) error {
 	}
 	data.Password = string(hashedPassword)
 	return nil
+}
+
+func shouldRevokeAdminUserTokensOnUpdate(data ent.UpdateAdminUserInput) bool {
+	if data.Password != nil {
+		return true
+	}
+
+	// Any role assignment/default-role mutation must invalidate active access tokens.
+	if data.Roles != nil || data.DefaultRole != nil {
+		return true
+	}
+	if data.DefaultRoleID != nil || data.ClearDefaultRole {
+		return true
+	}
+	if data.ClearRoles || len(data.AddRoleIDs) > 0 || len(data.RemoveRoleIDs) > 0 {
+		return true
+	}
+
+	return false
 }
 
 func (s *AdminUser) Get(ctx context.Context, where *ent.AdminUserWhereInput, orderBy *ent.AdminUserOrder, skip *int, first *int, last *int) ([]*ent.AdminUser, error) {
@@ -95,31 +115,170 @@ func (s *AdminUser) CreateManyTx(ctx context.Context, tx *ent.Tx, data []ent.Cre
 }
 
 func (s *AdminUser) Update(ctx context.Context, where ent.AdminUserWhereUniqueInput, data ent.UpdateAdminUserInput) (*ent.AdminUser, error) {
+	shouldRevoke := shouldRevokeAdminUserTokensOnUpdate(data)
+
+	var before *ent.AdminUser
+	var err error
+	if shouldRevoke {
+		before, err = s.repository.AdminUser.GetOne(ctx, where)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err := hashPasswordAdminUserUpdate(&data); err != nil {
 		return nil, err
 	}
-	return s.repository.AdminUser.Update(ctx, where, data)
+
+	updated, err := s.repository.AdminUser.Update(ctx, where, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldRevoke {
+		subjects := []subjectRevocation{{
+			Email:       before.Email,
+			SubjectType: jwtrefresh.SubjectTypeAdmin,
+		}}
+
+		if data.Email != nil {
+			subjects = append(subjects, subjectRevocation{
+				Email:       *data.Email,
+				SubjectType: jwtrefresh.SubjectTypeAdmin,
+			})
+		}
+
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return nil, err
+		}
+	}
+
+	return updated, nil
 }
 
 func (s *AdminUser) UpdateTx(ctx context.Context, tx *ent.Tx, where ent.AdminUserWhereUniqueInput, data ent.UpdateAdminUserInput) (*ent.AdminUser, error) {
+	shouldRevoke := shouldRevokeAdminUserTokensOnUpdate(data)
+
+	var before *ent.AdminUser
+	var err error
+	if shouldRevoke {
+		before, err = s.repository.AdminUser.GetOneTx(ctx, tx, where)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err := hashPasswordAdminUserUpdate(&data); err != nil {
 		return nil, err
 	}
-	return s.repository.AdminUser.UpdateTx(ctx, tx, where, data)
+
+	updated, err := s.repository.AdminUser.UpdateTx(ctx, tx, where, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldRevoke {
+		subjects := []subjectRevocation{{
+			Email:       before.Email,
+			SubjectType: jwtrefresh.SubjectTypeAdmin,
+		}}
+
+		if data.Email != nil {
+			subjects = append(subjects, subjectRevocation{
+				Email:       *data.Email,
+				SubjectType: jwtrefresh.SubjectTypeAdmin,
+			})
+		}
+
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return nil, err
+		}
+	}
+
+	return updated, nil
 }
 
 func (s *AdminUser) UpdateMany(ctx context.Context, where ent.AdminUserWhereInput, data ent.UpdateAdminUserInput) (int, error) {
+	shouldRevoke := shouldRevokeAdminUserTokensOnUpdate(data)
+
+	var subjects []subjectRevocation
+	var err error
+	if shouldRevoke {
+		users, getErr := s.repository.AdminUser.Get(ctx, &where, nil, nil, nil, nil)
+		if getErr != nil {
+			return 0, getErr
+		}
+		for _, user := range users {
+			subjects = append(subjects, subjectRevocation{
+				Email:       user.Email,
+				SubjectType: jwtrefresh.SubjectTypeAdmin,
+			})
+		}
+	}
+
 	if err := hashPasswordAdminUserUpdate(&data); err != nil {
 		return 0, err
 	}
-	return s.repository.AdminUser.UpdateMany(ctx, where, data)
+
+	updatedRows, err := s.repository.AdminUser.UpdateMany(ctx, where, data)
+	if err != nil {
+		return 0, err
+	}
+
+	if shouldRevoke && updatedRows > 0 {
+		if data.Email != nil {
+			subjects = append(subjects, subjectRevocation{
+				Email:       *data.Email,
+				SubjectType: jwtrefresh.SubjectTypeAdmin,
+			})
+		}
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return updatedRows, nil
 }
 
 func (s *AdminUser) UpdateManyTx(ctx context.Context, tx *ent.Tx, where ent.AdminUserWhereInput, data ent.UpdateAdminUserInput) (int, error) {
+	shouldRevoke := shouldRevokeAdminUserTokensOnUpdate(data)
+
+	var subjects []subjectRevocation
+	if shouldRevoke {
+		users, err := s.repository.AdminUser.GetTx(ctx, tx, &where, nil, nil, nil, nil)
+		if err != nil {
+			return 0, err
+		}
+		for _, user := range users {
+			subjects = append(subjects, subjectRevocation{
+				Email:       user.Email,
+				SubjectType: jwtrefresh.SubjectTypeAdmin,
+			})
+		}
+	}
+
 	if err := hashPasswordAdminUserUpdate(&data); err != nil {
 		return 0, err
 	}
-	return s.repository.AdminUser.UpdateManyTx(ctx, tx, where, data)
+
+	updatedRows, err := s.repository.AdminUser.UpdateManyTx(ctx, tx, where, data)
+	if err != nil {
+		return 0, err
+	}
+
+	if shouldRevoke && updatedRows > 0 {
+		if data.Email != nil {
+			subjects = append(subjects, subjectRevocation{
+				Email:       *data.Email,
+				SubjectType: jwtrefresh.SubjectTypeAdmin,
+			})
+		}
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return updatedRows, nil
 }
 
 func (s *AdminUser) Upsert(ctx context.Context, data ent.CreateAdminUserInput) (*ent.AdminUser, error) {
@@ -163,17 +322,97 @@ func (s *AdminUser) UpdatePassword(ctx context.Context, where ent.AdminUserWhere
 }
 
 func (s *AdminUser) Delete(ctx context.Context, where ent.AdminUserWhereUniqueInput) (*ent.AdminUser, error) {
-	return s.repository.AdminUser.Delete(ctx, where)
+	user, err := s.repository.AdminUser.GetOne(ctx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	deleted, err := s.repository.AdminUser.Delete(ctx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := revokeSubjects(ctx, s.repository, []subjectRevocation{{
+		Email:       user.Email,
+		SubjectType: jwtrefresh.SubjectTypeAdmin,
+	}}); err != nil {
+		return nil, err
+	}
+
+	return deleted, nil
 }
 
 func (s *AdminUser) DeleteTx(ctx context.Context, tx *ent.Tx, where ent.AdminUserWhereUniqueInput) (*ent.AdminUser, error) {
-	return s.repository.AdminUser.DeleteTx(ctx, tx, where)
+	user, err := s.repository.AdminUser.GetOneTx(ctx, tx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	deleted, err := s.repository.AdminUser.DeleteTx(ctx, tx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := revokeSubjects(ctx, s.repository, []subjectRevocation{{
+		Email:       user.Email,
+		SubjectType: jwtrefresh.SubjectTypeAdmin,
+	}}); err != nil {
+		return nil, err
+	}
+
+	return deleted, nil
 }
 
 func (s *AdminUser) DeleteMany(ctx context.Context, where ent.AdminUserWhereInput) (int, error) {
-	return s.repository.AdminUser.DeleteMany(ctx, where)
+	users, err := s.repository.AdminUser.Get(ctx, &where, nil, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	deletedRows, err := s.repository.AdminUser.DeleteMany(ctx, where)
+	if err != nil {
+		return 0, err
+	}
+
+	if deletedRows > 0 {
+		subjects := make([]subjectRevocation, 0, len(users))
+		for _, user := range users {
+			subjects = append(subjects, subjectRevocation{
+				Email:       user.Email,
+				SubjectType: jwtrefresh.SubjectTypeAdmin,
+			})
+		}
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return deletedRows, nil
 }
 
 func (s *AdminUser) DeleteManyTx(ctx context.Context, tx *ent.Tx, where ent.AdminUserWhereInput) (int, error) {
-	return s.repository.AdminUser.DeleteManyTx(ctx, tx, where)
+	users, err := s.repository.AdminUser.GetTx(ctx, tx, &where, nil, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	deletedRows, err := s.repository.AdminUser.DeleteManyTx(ctx, tx, where)
+	if err != nil {
+		return 0, err
+	}
+
+	if deletedRows > 0 {
+		subjects := make([]subjectRevocation, 0, len(users))
+		for _, user := range users {
+			subjects = append(subjects, subjectRevocation{
+				Email:       user.Email,
+				SubjectType: jwtrefresh.SubjectTypeAdmin,
+			})
+		}
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return deletedRows, nil
 }

--- a/entgql/domain/svc/role.go
+++ b/entgql/domain/svc/role.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/GoLabra/labra/entgql/domain/repo"
 	"github.com/GoLabra/labra/entgql/ent"
+	"github.com/GoLabra/labra/jwtrefresh"
 )
 
 type Role struct {
@@ -60,19 +61,109 @@ func (s *Role) CreateManyTx(ctx context.Context, tx *ent.Tx, data []ent.CreateRo
 }
 
 func (s *Role) Update(ctx context.Context, where ent.RoleWhereUniqueInput, data ent.UpdateRoleInput) (*ent.Role, error) {
-	return s.repository.Role.Update(ctx, where, data)
+	role, err := s.repository.Role.GetOne(ctx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	subjects, err := s.subjectsForRoleIDs(ctx, nil, []string{role.ID})
+	if err != nil {
+		return nil, err
+	}
+
+	updated, err := s.repository.Role.Update(ctx, where, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+		return nil, err
+	}
+
+	return updated, nil
 }
 
 func (s *Role) UpdateTx(ctx context.Context, tx *ent.Tx, where ent.RoleWhereUniqueInput, data ent.UpdateRoleInput) (*ent.Role, error) {
-	return s.repository.Role.UpdateTx(ctx, tx, where, data)
+	role, err := s.repository.Role.GetOneTx(ctx, tx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	subjects, err := s.subjectsForRoleIDs(ctx, tx, []string{role.ID})
+	if err != nil {
+		return nil, err
+	}
+
+	updated, err := s.repository.Role.UpdateTx(ctx, tx, where, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+		return nil, err
+	}
+
+	return updated, nil
 }
 
 func (s *Role) UpdateMany(ctx context.Context, where ent.RoleWhereInput, data ent.UpdateRoleInput) (int, error) {
-	return s.repository.Role.UpdateMany(ctx, where, data)
+	roles, err := s.repository.Role.Get(ctx, &where, nil, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	roleIDs := make([]string, 0, len(roles))
+	for _, role := range roles {
+		roleIDs = append(roleIDs, role.ID)
+	}
+
+	subjects, err := s.subjectsForRoleIDs(ctx, nil, roleIDs)
+	if err != nil {
+		return 0, err
+	}
+
+	updatedRows, err := s.repository.Role.UpdateMany(ctx, where, data)
+	if err != nil {
+		return 0, err
+	}
+
+	if updatedRows > 0 {
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return updatedRows, nil
 }
 
 func (s *Role) UpdateManyTx(ctx context.Context, tx *ent.Tx, where ent.RoleWhereInput, data ent.UpdateRoleInput) (int, error) {
-	return s.repository.Role.UpdateManyTx(ctx, tx, where, data)
+	roles, err := s.repository.Role.GetTx(ctx, tx, &where, nil, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	roleIDs := make([]string, 0, len(roles))
+	for _, role := range roles {
+		roleIDs = append(roleIDs, role.ID)
+	}
+
+	subjects, err := s.subjectsForRoleIDs(ctx, tx, roleIDs)
+	if err != nil {
+		return 0, err
+	}
+
+	updatedRows, err := s.repository.Role.UpdateManyTx(ctx, tx, where, data)
+	if err != nil {
+		return 0, err
+	}
+
+	if updatedRows > 0 {
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return updatedRows, nil
 }
 
 func (s *Role) Upsert(ctx context.Context, data ent.CreateRoleInput) (*ent.Role, error) {
@@ -92,17 +183,174 @@ func (s *Role) UpsertManyTx(ctx context.Context, tx *ent.Tx, data []ent.CreateRo
 }
 
 func (s *Role) Delete(ctx context.Context, where ent.RoleWhereUniqueInput) (*ent.Role, error) {
-	return s.repository.Role.Delete(ctx, where)
+	role, err := s.repository.Role.GetOne(ctx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	subjects, err := s.subjectsForRoleIDs(ctx, nil, []string{role.ID})
+	if err != nil {
+		return nil, err
+	}
+
+	deleted, err := s.repository.Role.Delete(ctx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+		return nil, err
+	}
+
+	return deleted, nil
 }
 
 func (s *Role) DeleteTx(ctx context.Context, tx *ent.Tx, where ent.RoleWhereUniqueInput) (*ent.Role, error) {
-	return s.repository.Role.DeleteTx(ctx, tx, where)
+	role, err := s.repository.Role.GetOneTx(ctx, tx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	subjects, err := s.subjectsForRoleIDs(ctx, tx, []string{role.ID})
+	if err != nil {
+		return nil, err
+	}
+
+	deleted, err := s.repository.Role.DeleteTx(ctx, tx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+		return nil, err
+	}
+
+	return deleted, nil
 }
 
 func (s *Role) DeleteMany(ctx context.Context, where ent.RoleWhereInput) (int, error) {
-	return s.repository.Role.DeleteMany(ctx, where)
+	roles, err := s.repository.Role.Get(ctx, &where, nil, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	roleIDs := make([]string, 0, len(roles))
+	for _, role := range roles {
+		roleIDs = append(roleIDs, role.ID)
+	}
+
+	subjects, err := s.subjectsForRoleIDs(ctx, nil, roleIDs)
+	if err != nil {
+		return 0, err
+	}
+
+	deletedRows, err := s.repository.Role.DeleteMany(ctx, where)
+	if err != nil {
+		return 0, err
+	}
+
+	if deletedRows > 0 {
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return deletedRows, nil
 }
 
 func (s *Role) DeleteManyTx(ctx context.Context, tx *ent.Tx, where ent.RoleWhereInput) (int, error) {
-	return s.repository.Role.DeleteManyTx(ctx, tx, where)
+	roles, err := s.repository.Role.GetTx(ctx, tx, &where, nil, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	roleIDs := make([]string, 0, len(roles))
+	for _, role := range roles {
+		roleIDs = append(roleIDs, role.ID)
+	}
+
+	subjects, err := s.subjectsForRoleIDs(ctx, tx, roleIDs)
+	if err != nil {
+		return 0, err
+	}
+
+	deletedRows, err := s.repository.Role.DeleteManyTx(ctx, tx, where)
+	if err != nil {
+		return 0, err
+	}
+
+	if deletedRows > 0 {
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return deletedRows, nil
+}
+
+func (s *Role) subjectsForRoleIDs(ctx context.Context, tx *ent.Tx, roleIDs []string) ([]subjectRevocation, error) {
+	if len(roleIDs) == 0 {
+		return nil, nil
+	}
+
+	roleFilters := make([]*ent.RoleWhereInput, 0, len(roleIDs))
+	for _, roleID := range roleIDs {
+		roleID := roleID
+		roleFilters = append(roleFilters, &ent.RoleWhereInput{ID: &roleID})
+	}
+
+	adminUserWhere := &ent.AdminUserWhereInput{
+		Or: []*ent.AdminUserWhereInput{
+			{HasDefaultRoleWith: roleFilters},
+			{HasRolesWith: roleFilters},
+		},
+	}
+	userWhere := &ent.UserWhereInput{
+		Or: []*ent.UserWhereInput{
+			{HasDefaultRoleWith: roleFilters},
+			{HasRolesWith: roleFilters},
+		},
+	}
+
+	var (
+		adminUsers []*ent.AdminUser
+		users      []*ent.User
+		err        error
+	)
+
+	if tx == nil {
+		adminUsers, err = s.repository.AdminUser.Get(ctx, adminUserWhere, nil, nil, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		users, err = s.repository.User.Get(ctx, userWhere, nil, nil, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		adminUsers, err = s.repository.AdminUser.GetTx(ctx, tx, adminUserWhere, nil, nil, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		users, err = s.repository.User.GetTx(ctx, tx, userWhere, nil, nil, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	subjects := make([]subjectRevocation, 0, len(adminUsers)+len(users))
+	for _, adminUser := range adminUsers {
+		subjects = append(subjects, subjectRevocation{
+			Email:       adminUser.Email,
+			SubjectType: jwtrefresh.SubjectTypeAdmin,
+		})
+	}
+	for _, user := range users {
+		subjects = append(subjects, subjectRevocation{
+			Email:       user.Email,
+			SubjectType: jwtrefresh.SubjectTypeUser,
+		})
+	}
+
+	return subjects, nil
 }

--- a/entgql/domain/svc/token_revocation.go
+++ b/entgql/domain/svc/token_revocation.go
@@ -1,0 +1,57 @@
+package svc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/GoLabra/labra/entgql/domain/repo"
+	"github.com/GoLabra/labra/tokenrevocation"
+)
+
+type subjectRevocation struct {
+	Email       string
+	SubjectType string
+}
+
+func revokeSubjects(ctx context.Context, repository *repo.Repository, subjects []subjectRevocation) error {
+	if len(subjects) == 0 {
+		return nil
+	}
+	if repository == nil || repository.Client == nil {
+		return fmt.Errorf("repository client is not initialized")
+	}
+
+	dialect := repository.Client.DialectName()
+	if strings.TrimSpace(dialect) == "" {
+		return fmt.Errorf("database dialect is not available")
+	}
+
+	seen := make(map[string]struct{}, len(subjects))
+	revokedAt := time.Now().UTC()
+
+	for _, subject := range subjects {
+		email := normalizeRevocationEmail(subject.Email)
+		subjectType := strings.TrimSpace(subject.SubjectType)
+		if email == "" || subjectType == "" {
+			continue
+		}
+
+		key := subjectType + "\x00" + email
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		if err := tokenrevocation.RevokeSubjectTokens(ctx, repository.Client, dialect, email, subjectType, revokedAt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func normalizeRevocationEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/entgql/domain/svc/user.go
+++ b/entgql/domain/svc/user.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GoLabra/labra/entgql/domain/repo"
 	"github.com/GoLabra/labra/entgql/ent"
+	"github.com/GoLabra/labra/jwtrefresh"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -40,6 +41,25 @@ func hashPasswordUserCreate(data *ent.CreateUserInput) error {
 	}
 	data.Password = string(hashedPassword)
 	return nil
+}
+
+func shouldRevokeUserTokensOnUpdate(data ent.UpdateUserInput) bool {
+	if data.Password != nil {
+		return true
+	}
+
+	// Any role assignment/default-role mutation must invalidate active access tokens.
+	if data.Roles != nil || data.DefaultRole != nil {
+		return true
+	}
+	if data.DefaultRoleID != nil || data.ClearDefaultRole {
+		return true
+	}
+	if data.ClearRoles || len(data.AddRoleIDs) > 0 || len(data.RemoveRoleIDs) > 0 {
+		return true
+	}
+
+	return false
 }
 
 func (s *User) Get(ctx context.Context, where *ent.UserWhereInput, orderBy *ent.UserOrder, skip *int, first *int, last *int) ([]*ent.User, error) {
@@ -95,31 +115,169 @@ func (s *User) CreateManyTx(ctx context.Context, tx *ent.Tx, data []ent.CreateUs
 }
 
 func (s *User) Update(ctx context.Context, where ent.UserWhereUniqueInput, data ent.UpdateUserInput) (*ent.User, error) {
+	shouldRevoke := shouldRevokeUserTokensOnUpdate(data)
+
+	var before *ent.User
+	var err error
+	if shouldRevoke {
+		before, err = s.repository.User.GetOne(ctx, where)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err := hashPasswordUserUpdate(&data); err != nil {
 		return nil, err
 	}
-	return s.repository.User.Update(ctx, where, data)
+
+	updated, err := s.repository.User.Update(ctx, where, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldRevoke {
+		subjects := []subjectRevocation{{
+			Email:       before.Email,
+			SubjectType: jwtrefresh.SubjectTypeUser,
+		}}
+
+		if data.Email != nil {
+			subjects = append(subjects, subjectRevocation{
+				Email:       *data.Email,
+				SubjectType: jwtrefresh.SubjectTypeUser,
+			})
+		}
+
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return nil, err
+		}
+	}
+
+	return updated, nil
 }
 
 func (s *User) UpdateTx(ctx context.Context, tx *ent.Tx, where ent.UserWhereUniqueInput, data ent.UpdateUserInput) (*ent.User, error) {
+	shouldRevoke := shouldRevokeUserTokensOnUpdate(data)
+
+	var before *ent.User
+	var err error
+	if shouldRevoke {
+		before, err = s.repository.User.GetOneTx(ctx, tx, where)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err := hashPasswordUserUpdate(&data); err != nil {
 		return nil, err
 	}
-	return s.repository.User.UpdateTx(ctx, tx, where, data)
+
+	updated, err := s.repository.User.UpdateTx(ctx, tx, where, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldRevoke {
+		subjects := []subjectRevocation{{
+			Email:       before.Email,
+			SubjectType: jwtrefresh.SubjectTypeUser,
+		}}
+
+		if data.Email != nil {
+			subjects = append(subjects, subjectRevocation{
+				Email:       *data.Email,
+				SubjectType: jwtrefresh.SubjectTypeUser,
+			})
+		}
+
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return nil, err
+		}
+	}
+
+	return updated, nil
 }
 
 func (s *User) UpdateMany(ctx context.Context, where ent.UserWhereInput, data ent.UpdateUserInput) (int, error) {
+	shouldRevoke := shouldRevokeUserTokensOnUpdate(data)
+
+	var subjects []subjectRevocation
+	if shouldRevoke {
+		users, err := s.repository.User.Get(ctx, &where, nil, nil, nil, nil)
+		if err != nil {
+			return 0, err
+		}
+		for _, user := range users {
+			subjects = append(subjects, subjectRevocation{
+				Email:       user.Email,
+				SubjectType: jwtrefresh.SubjectTypeUser,
+			})
+		}
+	}
+
 	if err := hashPasswordUserUpdate(&data); err != nil {
 		return 0, err
 	}
-	return s.repository.User.UpdateMany(ctx, where, data)
+
+	updatedRows, err := s.repository.User.UpdateMany(ctx, where, data)
+	if err != nil {
+		return 0, err
+	}
+
+	if shouldRevoke && updatedRows > 0 {
+		if data.Email != nil {
+			subjects = append(subjects, subjectRevocation{
+				Email:       *data.Email,
+				SubjectType: jwtrefresh.SubjectTypeUser,
+			})
+		}
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return updatedRows, nil
 }
 
 func (s *User) UpdateManyTx(ctx context.Context, tx *ent.Tx, where ent.UserWhereInput, data ent.UpdateUserInput) (int, error) {
+	shouldRevoke := shouldRevokeUserTokensOnUpdate(data)
+
+	var subjects []subjectRevocation
+	if shouldRevoke {
+		users, err := s.repository.User.GetTx(ctx, tx, &where, nil, nil, nil, nil)
+		if err != nil {
+			return 0, err
+		}
+		for _, user := range users {
+			subjects = append(subjects, subjectRevocation{
+				Email:       user.Email,
+				SubjectType: jwtrefresh.SubjectTypeUser,
+			})
+		}
+	}
+
 	if err := hashPasswordUserUpdate(&data); err != nil {
 		return 0, err
 	}
-	return s.repository.User.UpdateManyTx(ctx, tx, where, data)
+
+	updatedRows, err := s.repository.User.UpdateManyTx(ctx, tx, where, data)
+	if err != nil {
+		return 0, err
+	}
+
+	if shouldRevoke && updatedRows > 0 {
+		if data.Email != nil {
+			subjects = append(subjects, subjectRevocation{
+				Email:       *data.Email,
+				SubjectType: jwtrefresh.SubjectTypeUser,
+			})
+		}
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return updatedRows, nil
 }
 
 func (s *User) Upsert(ctx context.Context, data ent.CreateUserInput) (*ent.User, error) {
@@ -155,17 +313,97 @@ func (s *User) UpsertManyTx(ctx context.Context, tx *ent.Tx, data []ent.CreateUs
 }
 
 func (s *User) Delete(ctx context.Context, where ent.UserWhereUniqueInput) (*ent.User, error) {
-	return s.repository.User.Delete(ctx, where)
+	user, err := s.repository.User.GetOne(ctx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	deleted, err := s.repository.User.Delete(ctx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := revokeSubjects(ctx, s.repository, []subjectRevocation{{
+		Email:       user.Email,
+		SubjectType: jwtrefresh.SubjectTypeUser,
+	}}); err != nil {
+		return nil, err
+	}
+
+	return deleted, nil
 }
 
 func (s *User) DeleteTx(ctx context.Context, tx *ent.Tx, where ent.UserWhereUniqueInput) (*ent.User, error) {
-	return s.repository.User.DeleteTx(ctx, tx, where)
+	user, err := s.repository.User.GetOneTx(ctx, tx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	deleted, err := s.repository.User.DeleteTx(ctx, tx, where)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := revokeSubjects(ctx, s.repository, []subjectRevocation{{
+		Email:       user.Email,
+		SubjectType: jwtrefresh.SubjectTypeUser,
+	}}); err != nil {
+		return nil, err
+	}
+
+	return deleted, nil
 }
 
 func (s *User) DeleteMany(ctx context.Context, where ent.UserWhereInput) (int, error) {
-	return s.repository.User.DeleteMany(ctx, where)
+	users, err := s.repository.User.Get(ctx, &where, nil, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	deletedRows, err := s.repository.User.DeleteMany(ctx, where)
+	if err != nil {
+		return 0, err
+	}
+
+	if deletedRows > 0 {
+		subjects := make([]subjectRevocation, 0, len(users))
+		for _, user := range users {
+			subjects = append(subjects, subjectRevocation{
+				Email:       user.Email,
+				SubjectType: jwtrefresh.SubjectTypeUser,
+			})
+		}
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return deletedRows, nil
 }
 
 func (s *User) DeleteManyTx(ctx context.Context, tx *ent.Tx, where ent.UserWhereInput) (int, error) {
-	return s.repository.User.DeleteManyTx(ctx, tx, where)
+	users, err := s.repository.User.GetTx(ctx, tx, &where, nil, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	deletedRows, err := s.repository.User.DeleteManyTx(ctx, tx, where)
+	if err != nil {
+		return 0, err
+	}
+
+	if deletedRows > 0 {
+		subjects := make([]subjectRevocation, 0, len(users))
+		for _, user := range users {
+			subjects = append(subjects, subjectRevocation{
+				Email:       user.Email,
+				SubjectType: jwtrefresh.SubjectTypeUser,
+			})
+		}
+		if err := revokeSubjects(ctx, s.repository, subjects); err != nil {
+			return 0, err
+		}
+	}
+
+	return deletedRows, nil
 }

--- a/entgql/ent/client_ext.go
+++ b/entgql/ent/client_ext.go
@@ -1,0 +1,14 @@
+package ent
+
+// DialectName returns the active SQL dialect for the client.
+func (c *Client) DialectName() string {
+	if c == nil || c.driver == nil {
+		return ""
+	}
+
+	if d, ok := c.driver.(interface{ Dialect() string }); ok {
+		return d.Dialect()
+	}
+
+	return ""
+}

--- a/handler/authenticator.go
+++ b/handler/authenticator.go
@@ -6,15 +6,21 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/GoLabra/labra/config"
 	"github.com/GoLabra/labra/constants"
 	"github.com/GoLabra/labra/entgql/domain/svc"
 	"github.com/GoLabra/labra/entgql/ent"
+	"github.com/GoLabra/labra/jwtrefresh"
+	"github.com/GoLabra/labra/tokenrevocation"
 
 	jwt_hs "github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 )
+
+var tokenRevocationCleanupOnce sync.Once
 
 func isWebSocketUpgrade(r *http.Request) bool {
 	// RFC allows comma-separated values, so use Contains checks.
@@ -87,6 +93,24 @@ func validateCentrifugoTokenIfPresent(r *http.Request, appCfg *config.AppConfig,
 	return nil
 }
 
+func startTokenRevocationCleanupJob(adminEntClient *ent.Client) {
+	if adminEntClient == nil {
+		return
+	}
+
+	tokenRevocationCleanupOnce.Do(func() {
+		tokenrevocation.StartCleanupJob(
+			context.Background(),
+			adminEntClient,
+			adminEntClient.DialectName(),
+			time.Hour,
+			func(format string, args ...any) {
+				log.Printf(format, args...)
+			},
+		)
+	})
+}
+
 func Authenticator(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		service, ok := r.Context().Value(constants.AdminServiceContextValue).(*svc.Service)
@@ -102,6 +126,9 @@ func Authenticator(next http.Handler) http.Handler {
 			log.Println("config not found")
 			return
 		}
+
+		adminEntClient, _ := r.Context().Value(constants.AdminEntClientContextValue).(*ent.Client)
+		startTokenRevocationCleanupJob(adminEntClient)
 
 		// ✅ DO NOT bypass auth for WebSocket upgrades.
 		tokenString := extractJWTFromRequest(r)
@@ -136,6 +163,53 @@ func Authenticator(next http.Handler) http.Handler {
 			w.WriteHeader(http.StatusUnauthorized)
 			log.Println("missing sub claim")
 			return
+		}
+
+		tokenType := claimStringValue(claims, jwtrefresh.ClaimType)
+		if tokenType != "" && tokenType != jwtrefresh.TokenTypeAccess {
+			w.WriteHeader(http.StatusUnauthorized)
+			log.Println("invalid token type")
+			return
+		}
+
+		issuedAt, err := claimUnixTime(claims, "iat")
+		if err != nil {
+			issuedAt = time.Time{}
+		}
+
+		subjectType := claimStringValue(claims, jwtrefresh.ClaimSubjectType)
+		if subjectType == "" {
+			subjectType = jwtrefresh.SubjectTypeAdmin
+		}
+
+		if adminEntClient != nil {
+			dialect := adminEntClient.DialectName()
+
+			tokenRevoked, err := tokenrevocation.IsTokenRevoked(r.Context(), adminEntClient, dialect, tokenString)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				log.Printf("failed checking token blacklist: %v", err)
+				return
+			}
+			if tokenRevoked {
+				w.WriteHeader(http.StatusUnauthorized)
+				log.Println("token is revoked")
+				return
+			}
+
+			if !issuedAt.IsZero() {
+				subjectRevoked, err := tokenrevocation.IsSubjectTokenRevoked(r.Context(), adminEntClient, dialect, userEmail, subjectType, issuedAt)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					log.Printf("failed checking subject revocation: %v", err)
+					return
+				}
+				if subjectRevoked {
+					w.WriteHeader(http.StatusUnauthorized)
+					log.Println("token invalidated by subject revocation")
+					return
+				}
+			}
 		}
 
 		// Use internal context for authentication operations (bypasses permission checks)

--- a/handler/authenticator_revocation_test.go
+++ b/handler/authenticator_revocation_test.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoLabra/labra/config"
+	"github.com/GoLabra/labra/constants"
+	"github.com/GoLabra/labra/entgql/domain/svc"
+	"github.com/GoLabra/labra/jwtrefresh"
+	"github.com/GoLabra/labra/mocks"
+	"github.com/GoLabra/labra/tokenrevocation"
+	"github.com/golang-jwt/jwt"
+	"github.com/golang/mock/gomock"
+)
+
+func TestAuthenticator_RejectsRevokedToken(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAdminUser := mocks.NewMockAdminUser(ctrl)
+	mockRole := mocks.NewMockRole(ctrl)
+
+	secretKey := "test-secret-key-that-is-long-enough-for-validation-minimum-16-chars"
+	adminEntClient := newTestAdminEntClient(t)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"exp":          time.Now().Add(30 * time.Minute).Unix(),
+		"iat":          time.Now().Add(-time.Minute).Unix(),
+		"sub":          "revoked@example.com",
+		"role":         "Admin",
+		"typ":          jwtrefresh.TokenTypeAccess,
+		"subject_type": jwtrefresh.SubjectTypeAdmin,
+	})
+	tokenString, err := token.SignedString([]byte(secretKey))
+	if err != nil {
+		t.Fatalf("failed signing token: %v", err)
+	}
+
+	if err := tokenrevocation.RevokeToken(
+		context.Background(),
+		adminEntClient,
+		adminEntClient.DialectName(),
+		tokenString,
+		"revoked@example.com",
+		jwtrefresh.SubjectTypeAdmin,
+		time.Now().Add(30*time.Minute),
+		time.Now(),
+	); err != nil {
+		t.Fatalf("failed revoking token: %v", err)
+	}
+
+	cfg := &config.AppConfig{
+		Secrets: config.Secrets{SecretKey: secretKey},
+	}
+	service := &svc.Service{
+		AdminUser: mockAdminUser,
+		Role:      mockRole,
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, constants.AdminServiceContextValue, service)
+	ctx = context.WithValue(ctx, constants.AdminEntClientContextValue, adminEntClient)
+	ctx = context.WithValue(ctx, "config", cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/query", nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+tokenString)
+
+	w := httptest.NewRecorder()
+	nextCalled := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		nextCalled = true
+	})
+
+	Authenticator(next).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+	if nextCalled {
+		t.Fatalf("next handler must not be called for revoked tokens")
+	}
+}

--- a/handler/login.go
+++ b/handler/login.go
@@ -7,13 +7,12 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/GoLabra/labra/config"
 	"github.com/GoLabra/labra/constants"
 	"github.com/GoLabra/labra/entgql/domain/svc"
 	"github.com/GoLabra/labra/entgql/ent"
-	"github.com/golang-jwt/jwt"
+	"github.com/GoLabra/labra/jwtrefresh"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -93,12 +92,6 @@ func Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var token = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"exp":  time.Now().Add(24 * time.Hour).Unix(),
-		"sub":  user.Email,
-		"role": role.Name,
-	})
-
 	appConfig, ok := r.Context().Value("config").(*config.AppConfig)
 
 	if !ok {
@@ -106,7 +99,13 @@ func Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	signedToken, err := token.SignedString([]byte(appConfig.SecretKey))
+	signedToken, _, err := jwtrefresh.IssueAccessToken(
+		appConfig.SecretKey,
+		user.Email,
+		role.Name,
+		jwtrefresh.SubjectTypeAdmin,
+		appConfig.AccessTokenTTL,
+	)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/handler/logout.go
+++ b/handler/logout.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/GoLabra/labra/config"
+	"github.com/GoLabra/labra/constants"
+	"github.com/GoLabra/labra/entgql/ent"
+	"github.com/GoLabra/labra/jwtrefresh"
+	"github.com/GoLabra/labra/tokenrevocation"
+
+	jwt_hs "github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+)
+
+func Logout(w http.ResponseWriter, r *http.Request) {
+	appConfig, ok := r.Context().Value("config").(*config.AppConfig)
+	if !ok {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println("config not found")
+		return
+	}
+
+	adminEntClient, ok := r.Context().Value(constants.AdminEntClientContextValue).(*ent.Client)
+	if !ok || adminEntClient == nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println("admin ent client not found")
+		return
+	}
+
+	startTokenRevocationCleanupJob(adminEntClient)
+
+	tokenString := extractJWTFromRequest(r)
+	if tokenString == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Println("token not found")
+		return
+	}
+
+	appJWT, err := jwt.ParseString(
+		tokenString,
+		jwt.WithValidate(true),
+		jwt.WithVerify(true),
+		jwt.WithKey(jwt_hs.HS256, []byte(appConfig.Secrets.SecretKey)),
+	)
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Printf("error parsing token: %v", err)
+		return
+	}
+
+	claims, err := appJWT.AsMap(r.Context())
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Printf("error parsing claims: %v", err)
+		return
+	}
+
+	subjectEmail := claimStringValue(claims, jwtrefresh.ClaimSubject)
+	if subjectEmail == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Println("missing sub claim")
+		return
+	}
+
+	subjectType := claimStringValue(claims, jwtrefresh.ClaimSubjectType)
+	if subjectType == "" {
+		subjectType = jwtrefresh.SubjectTypeAdmin
+	}
+
+	expiresAt, err := claimUnixTime(claims, "exp")
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Printf("missing/invalid exp claim: %v", err)
+		return
+	}
+
+	err = tokenrevocation.RevokeToken(
+		r.Context(),
+		adminEntClient,
+		adminEntClient.DialectName(),
+		tokenString,
+		subjectEmail,
+		subjectType,
+		expiresAt,
+		time.Now().UTC(),
+	)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("failed to revoke token during logout: %v", err)
+		return
+	}
+
+	ClearJWTCookie(w, r, "")
+	ClearCSRFCookie(w, isSecureRequest(r))
+
+	response, _ := json.Marshal(map[string]string{
+		"status": "logged_out",
+	})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(response)
+}

--- a/handler/logout_test.go
+++ b/handler/logout_test.go
@@ -1,0 +1,90 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoLabra/labra/config"
+	"github.com/GoLabra/labra/constants"
+	"github.com/GoLabra/labra/jwtrefresh"
+	"github.com/GoLabra/labra/tokenrevocation"
+	"github.com/golang-jwt/jwt"
+)
+
+func TestLogout_RevokesCurrentToken(t *testing.T) {
+	client := newTestAdminEntClient(t)
+	secretKey := "test-secret-key-that-is-long-enough-for-validation-minimum-16-chars"
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"exp":          time.Now().Add(30 * time.Minute).Unix(),
+		"iat":          time.Now().Add(-time.Minute).Unix(),
+		"sub":          "logout@example.com",
+		"role":         "Admin",
+		"typ":          jwtrefresh.TokenTypeAccess,
+		"subject_type": jwtrefresh.SubjectTypeAdmin,
+	})
+	tokenString, err := token.SignedString([]byte(secretKey))
+	if err != nil {
+		t.Fatalf("failed signing token: %v", err)
+	}
+
+	cfg := &config.AppConfig{
+		Secrets: config.Secrets{SecretKey: secretKey},
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "config", cfg)
+	ctx = context.WithValue(ctx, constants.AdminEntClientContextValue, client)
+
+	req := httptest.NewRequest(http.MethodPost, "/logout", nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+tokenString)
+	w := httptest.NewRecorder()
+
+	Logout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	revoked, err := tokenrevocation.IsTokenRevoked(context.Background(), client, client.DialectName(), tokenString)
+	if err != nil {
+		t.Fatalf("failed checking revoked token: %v", err)
+	}
+	if !revoked {
+		t.Fatalf("expected token to be revoked")
+	}
+
+	setCookie := strings.Join(w.Header().Values("Set-Cookie"), "\n")
+	if !strings.Contains(setCookie, "jwt=") {
+		t.Fatalf("expected jwt cookie to be cleared")
+	}
+	if !strings.Contains(setCookie, "csrf_token=") {
+		t.Fatalf("expected csrf cookie to be cleared")
+	}
+}
+
+func TestLogout_MissingToken(t *testing.T) {
+	client := newTestAdminEntClient(t)
+	cfg := &config.AppConfig{
+		Secrets: config.Secrets{
+			SecretKey: "test-secret-key-that-is-long-enough-for-validation-minimum-16-chars",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "config", cfg)
+	ctx = context.WithValue(ctx, constants.AdminEntClientContextValue, client)
+
+	req := httptest.NewRequest(http.MethodPost, "/logout", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	Logout(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+}

--- a/handler/session_role.go
+++ b/handler/session_role.go
@@ -2,13 +2,18 @@ package handler
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"time"
 
 	"github.com/GoLabra/labra/config"
 	"github.com/GoLabra/labra/constants"
 	"github.com/GoLabra/labra/entgql/ent"
-	"github.com/golang-jwt/jwt"
+	"github.com/GoLabra/labra/jwtrefresh"
+	"github.com/GoLabra/labra/tokenrevocation"
+
+	jwt_hs "github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 type ChangeSessionRoleRequest struct {
@@ -29,12 +34,6 @@ func ChangeSessionRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var token = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"exp":  time.Now().Add(24 * time.Hour).Unix(),
-		"sub":  user.Email,
-		"role": role.Name,
-	})
-
 	appConfig, ok := r.Context().Value("config").(*config.AppConfig)
 
 	if !ok {
@@ -42,9 +41,68 @@ func ChangeSessionRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	signedToken, err := token.SignedString([]byte(appConfig.SecretKey))
+	adminEntClient, _ := r.Context().Value(constants.AdminEntClientContextValue).(*ent.Client)
+	if adminEntClient != nil {
+		tokenString := extractJWTFromRequest(r)
+		if tokenString != "" {
+			appJWT, err := jwt.ParseString(
+				tokenString,
+				jwt.WithValidate(true),
+				jwt.WithVerify(true),
+				jwt.WithKey(jwt_hs.HS256, []byte(appConfig.Secrets.SecretKey)),
+			)
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				log.Printf("error parsing token: %v", err)
+				return
+			}
+
+			claims, err := appJWT.AsMap(r.Context())
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				log.Printf("error parsing claims: %v", err)
+				return
+			}
+
+			expiresAt, err := claimUnixTime(claims, "exp")
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				log.Printf("missing/invalid exp claim: %v", err)
+				return
+			}
+
+			subjectType := claimStringValue(claims, jwtrefresh.ClaimSubjectType)
+			if subjectType == "" {
+				subjectType = jwtrefresh.SubjectTypeAdmin
+			}
+
+			if err := tokenrevocation.RevokeToken(
+				r.Context(),
+				adminEntClient,
+				adminEntClient.DialectName(),
+				tokenString,
+				user.Email,
+				subjectType,
+				expiresAt,
+				time.Now().UTC(),
+			); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				log.Printf("failed revoking current session token: %v", err)
+				return
+			}
+		}
+	}
+
+	signedToken, _, err := jwtrefresh.IssueAccessToken(
+		appConfig.SecretKey,
+		user.Email,
+		role.Name,
+		jwtrefresh.SubjectTypeAdmin,
+		appConfig.AccessTokenTTL,
+	)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	response, _ := json.Marshal(map[string]string{

--- a/handler/test_helpers_test.go
+++ b/handler/test_helpers_test.go
@@ -1,0 +1,14 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/GoLabra/labra/entgql/ent"
+	"github.com/GoLabra/labra/entgql/ent/enttest"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newTestAdminEntClient(t *testing.T) *ent.Client {
+	t.Helper()
+	return enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+}

--- a/handler/token_claims.go
+++ b/handler/token_claims.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func claimStringValue(claims map[string]interface{}, key string) string {
+	raw, ok := claims[key]
+	if !ok || raw == nil {
+		return ""
+	}
+
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func claimUnixTime(claims map[string]interface{}, key string) (time.Time, error) {
+	raw, ok := claims[key]
+	if !ok || raw == nil {
+		return time.Time{}, fmt.Errorf("missing %s claim", key)
+	}
+
+	switch v := raw.(type) {
+	case time.Time:
+		return v.UTC(), nil
+	case *time.Time:
+		if v == nil {
+			return time.Time{}, fmt.Errorf("invalid %s claim", key)
+		}
+		return v.UTC(), nil
+	case int64:
+		return time.Unix(v, 0).UTC(), nil
+	case int:
+		return time.Unix(int64(v), 0).UTC(), nil
+	case int32:
+		return time.Unix(int64(v), 0).UTC(), nil
+	case float64:
+		return time.Unix(int64(v), 0).UTC(), nil
+	case float32:
+		return time.Unix(int64(v), 0).UTC(), nil
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid %s claim: %w", key, err)
+		}
+		return time.Unix(n, 0).UTC(), nil
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid %s claim: %w", key, err)
+		}
+		return time.Unix(n, 0).UTC(), nil
+	default:
+		return time.Time{}, fmt.Errorf("invalid %s claim type %T", key, raw)
+	}
+}

--- a/jwtrefresh/jwtrefresh.go
+++ b/jwtrefresh/jwtrefresh.go
@@ -1,0 +1,51 @@
+package jwtrefresh
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+)
+
+const (
+	ClaimSubject     = "sub"
+	ClaimRole        = "role"
+	ClaimType        = "typ"
+	ClaimSubjectType = "subject_type"
+
+	TokenTypeAccess = "access"
+
+	SubjectTypeAdmin = "admin"
+	SubjectTypeUser  = "user"
+
+	DefaultAccessTokenTTL = 15 * time.Minute
+)
+
+func EffectiveAccessTTL(ttl time.Duration) time.Duration {
+	if ttl <= 0 {
+		return DefaultAccessTokenTTL
+	}
+	return ttl
+}
+
+func IssueAccessToken(secret, subject, role, subjectType string, ttl time.Duration) (string, time.Time, error) {
+	now := time.Now().UTC()
+	expiresAt := now.Add(EffectiveAccessTTL(ttl))
+
+	claims := jwt.MapClaims{
+		"exp":            expiresAt.Unix(),
+		"iat":            now.Unix(),
+		ClaimSubject:     subject,
+		ClaimRole:        role,
+		ClaimType:        TokenTypeAccess,
+		ClaimSubjectType: subjectType,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(secret))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("sign access token: %w", err)
+	}
+
+	return signed, expiresAt, nil
+}

--- a/resources/app/handler/logout.go
+++ b/resources/app/handler/logout.go
@@ -1,0 +1,153 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"app/ent"
+	"github.com/GoLabra/labra/config"
+	"github.com/GoLabra/labra/constants"
+	"github.com/GoLabra/labra/jwtrefresh"
+	"github.com/GoLabra/labra/tokenrevocation"
+
+	jwt_hs "github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+)
+
+func Logout(w http.ResponseWriter, r *http.Request) {
+	appConfig, ok := r.Context().Value("config").(*config.AppConfig)
+	if !ok {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println("config not found")
+		return
+	}
+
+	entClient, ok := r.Context().Value(constants.EntClientContextValue).(*ent.Client)
+	if !ok || entClient == nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Println("ent client not found")
+		return
+	}
+
+	tokenString := extractJWTFromRequest(r)
+	if tokenString == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Println("token not found")
+		return
+	}
+
+	appJWT, err := jwt.ParseString(
+		tokenString,
+		jwt.WithValidate(true),
+		jwt.WithVerify(true),
+		jwt.WithKey(jwt_hs.HS256, []byte(appConfig.SecretKey)),
+	)
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Printf("error parsing token: %v", err)
+		return
+	}
+
+	claims, err := appJWT.AsMap(r.Context())
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Printf("error parsing claims: %v", err)
+		return
+	}
+
+	subjectEmail := claimStringValue(claims, jwtrefresh.ClaimSubject)
+	if subjectEmail == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Println("missing sub claim")
+		return
+	}
+
+	subjectType := claimStringValue(claims, jwtrefresh.ClaimSubjectType)
+	if subjectType == "" {
+		subjectType = jwtrefresh.SubjectTypeUser
+	}
+
+	expiresAt, err := claimUnixTime(claims, "exp")
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		log.Printf("missing/invalid exp claim: %v", err)
+		return
+	}
+
+	err = tokenrevocation.RevokeToken(
+		r.Context(),
+		entClient,
+		appConfig.DBDialect,
+		tokenString,
+		subjectEmail,
+		subjectType,
+		expiresAt,
+		time.Now().UTC(),
+	)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("failed to revoke token during logout: %v", err)
+		return
+	}
+
+	response, _ := json.Marshal(map[string]string{
+		"status": "logged_out",
+	})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(response)
+}
+
+func claimStringValue(claims map[string]interface{}, key string) string {
+	raw, ok := claims[key]
+	if !ok || raw == nil {
+		return ""
+	}
+
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func claimUnixTime(claims map[string]interface{}, key string) (time.Time, error) {
+	raw, ok := claims[key]
+	if !ok || raw == nil {
+		return time.Time{}, fmt.Errorf("missing %s claim", key)
+	}
+
+	switch v := raw.(type) {
+	case time.Time:
+		return v.UTC(), nil
+	case *time.Time:
+		if v == nil {
+			return time.Time{}, fmt.Errorf("invalid %s claim", key)
+		}
+		return v.UTC(), nil
+	case int64:
+		return time.Unix(v, 0).UTC(), nil
+	case int:
+		return time.Unix(int64(v), 0).UTC(), nil
+	case int32:
+		return time.Unix(int64(v), 0).UTC(), nil
+	case float64:
+		return time.Unix(int64(v), 0).UTC(), nil
+	case float32:
+		return time.Unix(int64(v), 0).UTC(), nil
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid %s claim: %w", key, err)
+		}
+		return time.Unix(n, 0).UTC(), nil
+	default:
+		return time.Time{}, fmt.Errorf("invalid %s claim type %T", key, raw)
+	}
+}

--- a/resources/app/main.go
+++ b/resources/app/main.go
@@ -122,7 +122,7 @@ func main() {
 	utils.LoadSchema(appConfig)
 
 	adminClient, adminRepository, adminService, adminResolver := InitAdmin(drv)
-	_, repository, service, resolver := InitApp(drv, adminClient, adminRepository, adminService)
+	client, repository, service, resolver := InitApp(drv, adminClient, adminRepository, adminService)
 
 	graphqlSubscriptionClient := subscription.NewGraphqlSubscriptionClient()
 
@@ -164,8 +164,10 @@ func main() {
 			var ctx = r.Context()
 			ctx = context.WithValue(ctx, constants.AdminServiceContextValue, adminService)
 			ctx = context.WithValue(ctx, constants.AdminRepositoryContextValue, adminRepository)
+			ctx = context.WithValue(ctx, constants.AdminEntClientContextValue, adminClient)
 			ctx = context.WithValue(ctx, constants.ServiceContextValue, service)
 			ctx = context.WithValue(ctx, constants.RepositoryContextValue, repository)
+			ctx = context.WithValue(ctx, constants.EntClientContextValue, client)
 			ctx = context.WithValue(ctx, constants.CentrifugeClientContextValue, gocentClient)
 			ctx = context.WithValue(ctx, "config", appConfig)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/resources/app/main.go
+++ b/resources/app/main.go
@@ -203,6 +203,7 @@ func main() {
 		router.Use(apiLimiter.Middleware)
 
 		router.Post("/change-session-role", handler.ChangeSessionRole)
+		router.Post("/logout", handler.Logout)
 	})
 	router.Group(func(router chi.Router) {
 		router.With(loginLimiter.Middleware).Post("/login", handler.Login)
@@ -240,6 +241,7 @@ func main() {
 		router.Use(apiLimiter.Middleware)
 
 		router.Post("/admin/change-session-role", adminHandler.ChangeSessionRole)
+		router.Post("/admin/logout", adminHandler.Logout)
 	})
 	router.Group(func(router chi.Router) {
 		router.With(loginLimiter.Middleware).Post("/admin/login", adminHandler.Login)

--- a/tokenrevocation/tokenrevocation.go
+++ b/tokenrevocation/tokenrevocation.go
@@ -1,0 +1,298 @@
+package tokenrevocation
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	defaultCleanupInterval = time.Hour
+)
+
+type SQLExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func HashToken(rawToken string) string {
+	sum := sha256.Sum256([]byte(rawToken))
+	return hex.EncodeToString(sum[:])
+}
+
+func EnsureTokenRevocationTables(ctx context.Context, db SQLExecutor) error {
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS token_blacklist (
+	token_hash VARCHAR(64) PRIMARY KEY,
+	subject_email VARCHAR(254) NOT NULL,
+	subject_type VARCHAR(16) NOT NULL,
+	expires_at_unix BIGINT NOT NULL,
+	revoked_at_unix BIGINT NOT NULL,
+	created_at_unix BIGINT NOT NULL
+)`,
+		`CREATE INDEX IF NOT EXISTS idx_token_blacklist_subject ON token_blacklist(subject_email, subject_type)`,
+		`CREATE INDEX IF NOT EXISTS idx_token_blacklist_expires_at ON token_blacklist(expires_at_unix)`,
+		`CREATE TABLE IF NOT EXISTS subject_token_revocations (
+	subject_email VARCHAR(254) NOT NULL,
+	subject_type VARCHAR(16) NOT NULL,
+	revoked_after_unix BIGINT NOT NULL,
+	updated_at_unix BIGINT NOT NULL,
+	PRIMARY KEY (subject_email, subject_type)
+)`,
+	}
+
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func RevokeToken(ctx context.Context, db SQLExecutor, dialect, rawToken, subjectEmail, subjectType string, expiresAt, revokedAt time.Time) error {
+	if err := EnsureTokenRevocationTables(ctx, db); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(rawToken) == "" {
+		return fmt.Errorf("token is required")
+	}
+
+	revokedAtUnix := revokedAt.UTC().Unix()
+	createdAtUnix := time.Now().UTC().Unix()
+	expiresAtUnix := expiresAt.UTC().Unix()
+	if expiresAtUnix <= 0 {
+		expiresAtUnix = revokedAt.UTC().Add(24 * time.Hour).Unix()
+	}
+
+	query := tokenUpsertQuery(dialect)
+	_, err := db.ExecContext(
+		ctx,
+		query,
+		HashToken(rawToken),
+		subjectEmail,
+		subjectType,
+		expiresAtUnix,
+		revokedAtUnix,
+		createdAtUnix,
+	)
+	return err
+}
+
+func RevokeSubjectTokens(ctx context.Context, db SQLExecutor, dialect, subjectEmail, subjectType string, revokedAt time.Time) error {
+	if err := EnsureTokenRevocationTables(ctx, db); err != nil {
+		return err
+	}
+	if strings.TrimSpace(subjectEmail) == "" {
+		return fmt.Errorf("subject email is required")
+	}
+	if strings.TrimSpace(subjectType) == "" {
+		return fmt.Errorf("subject type is required")
+	}
+
+	// JWT iat is second-precision in this codebase. Bumping the cutoff by one second
+	// guarantees that tokens issued in the revocation second are invalidated too.
+	revokedAfterUnix := revokedAt.UTC().Unix() + 1
+	updatedAtUnix := time.Now().UTC().Unix()
+
+	query := subjectRevocationUpsertQuery(dialect)
+	_, err := db.ExecContext(
+		ctx,
+		query,
+		subjectEmail,
+		subjectType,
+		revokedAfterUnix,
+		updatedAtUnix,
+	)
+	return err
+}
+
+func IsTokenRevoked(ctx context.Context, db SQLExecutor, dialect, rawToken string) (bool, error) {
+	if err := EnsureTokenRevocationTables(ctx, db); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(rawToken) == "" {
+		return false, nil
+	}
+
+	query := fmt.Sprintf(
+		"SELECT 1 FROM token_blacklist WHERE token_hash = %s LIMIT 1",
+		bindVar(dialect, 1),
+	)
+
+	rows, err := db.QueryContext(ctx, query, HashToken(rawToken))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	return rows.Next(), rows.Err()
+}
+
+func IsSubjectTokenRevoked(ctx context.Context, db SQLExecutor, dialect, subjectEmail, subjectType string, issuedAt time.Time) (bool, error) {
+	if err := EnsureTokenRevocationTables(ctx, db); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(subjectEmail) == "" || strings.TrimSpace(subjectType) == "" || issuedAt.IsZero() {
+		return false, nil
+	}
+
+	query := fmt.Sprintf(
+		"SELECT revoked_after_unix FROM subject_token_revocations WHERE subject_email = %s AND subject_type = %s LIMIT 1",
+		bindVar(dialect, 1),
+		bindVar(dialect, 2),
+	)
+
+	rows, err := db.QueryContext(ctx, query, subjectEmail, subjectType)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		return false, rows.Err()
+	}
+
+	var revokedAfterUnix int64
+	if err := rows.Scan(&revokedAfterUnix); err != nil {
+		return false, err
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+
+	// Use strict comparison to avoid invalidating a token issued in the same second.
+	return issuedAt.UTC().Unix() < revokedAfterUnix, nil
+}
+
+func CleanupExpiredRevocations(ctx context.Context, db SQLExecutor, dialect string, now time.Time) (int64, error) {
+	if err := EnsureTokenRevocationTables(ctx, db); err != nil {
+		return 0, err
+	}
+
+	query := fmt.Sprintf(
+		"DELETE FROM token_blacklist WHERE expires_at_unix <= %s",
+		bindVar(dialect, 1),
+	)
+
+	result, err := db.ExecContext(ctx, query, now.UTC().Unix())
+	if err != nil {
+		return 0, err
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	return affected, nil
+}
+
+func StartCleanupJob(ctx context.Context, db SQLExecutor, dialect string, interval time.Duration, logf func(string, ...any)) {
+	if interval <= 0 {
+		interval = defaultCleanupInterval
+	}
+
+	go func() {
+		// Initial cleanup to handle stale data after deploy/restart.
+		if _, err := CleanupExpiredRevocations(ctx, db, dialect, time.Now().UTC()); err != nil && logf != nil {
+			logf("token revocation cleanup failed: %v", err)
+		}
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, err := CleanupExpiredRevocations(ctx, db, dialect, time.Now().UTC()); err != nil && logf != nil {
+					logf("token revocation cleanup failed: %v", err)
+				}
+			}
+		}
+	}()
+}
+
+func tokenUpsertQuery(dialect string) string {
+	switch normalizeDialect(dialect) {
+	case "postgres":
+		return `
+INSERT INTO token_blacklist (token_hash, subject_email, subject_type, expires_at_unix, revoked_at_unix, created_at_unix)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (token_hash) DO UPDATE
+SET subject_email = EXCLUDED.subject_email,
+	subject_type = EXCLUDED.subject_type,
+	expires_at_unix = EXCLUDED.expires_at_unix,
+	revoked_at_unix = EXCLUDED.revoked_at_unix`
+	case "mysql":
+		return `
+INSERT INTO token_blacklist (token_hash, subject_email, subject_type, expires_at_unix, revoked_at_unix, created_at_unix)
+VALUES (?, ?, ?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+	subject_email = VALUES(subject_email),
+	subject_type = VALUES(subject_type),
+	expires_at_unix = VALUES(expires_at_unix),
+	revoked_at_unix = VALUES(revoked_at_unix)`
+	default:
+		return `
+INSERT INTO token_blacklist (token_hash, subject_email, subject_type, expires_at_unix, revoked_at_unix, created_at_unix)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(token_hash) DO UPDATE
+SET subject_email = excluded.subject_email,
+	subject_type = excluded.subject_type,
+	expires_at_unix = excluded.expires_at_unix,
+	revoked_at_unix = excluded.revoked_at_unix`
+	}
+}
+
+func subjectRevocationUpsertQuery(dialect string) string {
+	switch normalizeDialect(dialect) {
+	case "postgres":
+		return `
+INSERT INTO subject_token_revocations (subject_email, subject_type, revoked_after_unix, updated_at_unix)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (subject_email, subject_type) DO UPDATE
+SET revoked_after_unix = CASE
+	WHEN subject_token_revocations.revoked_after_unix > EXCLUDED.revoked_after_unix
+	THEN subject_token_revocations.revoked_after_unix
+	ELSE EXCLUDED.revoked_after_unix
+END,
+updated_at_unix = EXCLUDED.updated_at_unix`
+	case "mysql":
+		return `
+INSERT INTO subject_token_revocations (subject_email, subject_type, revoked_after_unix, updated_at_unix)
+VALUES (?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+	revoked_after_unix = GREATEST(revoked_after_unix, VALUES(revoked_after_unix)),
+	updated_at_unix = VALUES(updated_at_unix)`
+	default:
+		return `
+INSERT INTO subject_token_revocations (subject_email, subject_type, revoked_after_unix, updated_at_unix)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(subject_email, subject_type) DO UPDATE
+SET revoked_after_unix = CASE
+	WHEN subject_token_revocations.revoked_after_unix > excluded.revoked_after_unix
+	THEN subject_token_revocations.revoked_after_unix
+	ELSE excluded.revoked_after_unix
+END,
+updated_at_unix = excluded.updated_at_unix`
+	}
+}
+
+func normalizeDialect(dialect string) string {
+	return strings.ToLower(strings.TrimSpace(dialect))
+}
+
+func bindVar(dialect string, position int) string {
+	if normalizeDialect(dialect) == "postgres" {
+		return fmt.Sprintf("$%d", position)
+	}
+	return "?"
+}

--- a/tokenrevocation/tokenrevocation_test.go
+++ b/tokenrevocation/tokenrevocation_test.go
@@ -1,0 +1,95 @@
+package tokenrevocation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"entgo.io/ent/dialect"
+	"github.com/GoLabra/labra/entgql/ent"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestRevokeTokenAndCleanup(t *testing.T) {
+	client := newTestEntClient(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(30 * time.Minute)
+
+	if err := RevokeToken(ctx, client, client.DialectName(), "access-token-1", "admin@example.com", "admin", expiresAt, now); err != nil {
+		t.Fatalf("revoke token failed: %v", err)
+	}
+
+	revoked, err := IsTokenRevoked(ctx, client, client.DialectName(), "access-token-1")
+	if err != nil {
+		t.Fatalf("is token revoked failed: %v", err)
+	}
+	if !revoked {
+		t.Fatalf("expected token to be revoked")
+	}
+
+	deleted, err := CleanupExpiredRevocations(ctx, client, client.DialectName(), now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected one deleted row, got %d", deleted)
+	}
+
+	revoked, err = IsTokenRevoked(ctx, client, client.DialectName(), "access-token-1")
+	if err != nil {
+		t.Fatalf("is token revoked failed after cleanup: %v", err)
+	}
+	if revoked {
+		t.Fatalf("expected token revocation row to be cleaned up")
+	}
+}
+
+func TestRevokeSubjectTokens(t *testing.T) {
+	client := newTestEntClient(t)
+	ctx := context.Background()
+
+	revokedAt := time.Now().UTC()
+	if err := RevokeSubjectTokens(ctx, client, client.DialectName(), "user@example.com", "admin", revokedAt); err != nil {
+		t.Fatalf("revoke subject tokens failed: %v", err)
+	}
+
+	revoked, err := IsSubjectTokenRevoked(ctx, client, client.DialectName(), "user@example.com", "admin", revokedAt.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("is subject token revoked failed: %v", err)
+	}
+	if !revoked {
+		t.Fatalf("expected older token to be revoked")
+	}
+
+	revoked, err = IsSubjectTokenRevoked(ctx, client, client.DialectName(), "user@example.com", "admin", revokedAt)
+	if err != nil {
+		t.Fatalf("is subject token revoked failed: %v", err)
+	}
+	if !revoked {
+		t.Fatalf("expected token issued in revocation second to be revoked")
+	}
+
+	revoked, err = IsSubjectTokenRevoked(ctx, client, client.DialectName(), "user@example.com", "admin", revokedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("is subject token revoked failed: %v", err)
+	}
+	if revoked {
+		t.Fatalf("expected newer token to remain valid")
+	}
+}
+
+func newTestEntClient(t *testing.T) *ent.Client {
+	t.Helper()
+
+	client, err := ent.Open(dialect.SQLite, "file:token-revocation-test?mode=memory&cache=shared&_fk=1")
+	if err != nil {
+		t.Fatalf("failed opening sqlite client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	return client
+}


### PR DESCRIPTION
## Summary

This PR introduces access-token revocation (blacklist) with logout enforcement for both admin and app flows.

It adds:
- Persistent token revocation storage (`token_revocation` table access layer)
- Logout endpoints that revoke current access token
- Authenticator checks that reject revoked access tokens
- Shared token-claim extraction helpers
- Coverage tests for revoked-token rejection and logout behavior

## What We Had To Do

Implement revocation controls that:
- Invalidate an issued access token before natural expiry
- Ensure logout immediately blocks token reuse
- Enforce revocation in request authentication middleware
- Work consistently across admin and app handlers
- Keep this branch buildable from `develop` without depending on jwt-refresh PR

## What We Achieved

- Added token revocation package:
  - `tokenrevocation/tokenrevocation.go`
  - `tokenrevocation/tokenrevocation_test.go`
- Added service layer wiring:
  - `entgql/domain/svc/token_revocation.go`
  - service/repository integrations in admin/user/role services
- Added logout support:
  - `handler/logout.go`
  - `resources/app/handler/logout.go`
- Added revoked-token enforcement in auth middleware:
  - `handler/authenticator.go`
  - helper claims parsing in `handler/token_claims.go`
- Added tests:
  - `handler/authenticator_revocation_test.go`
  - `handler/logout_test.go`
- Added compatibility pieces so the branch compiles independently from `develop`:
  - `jwtrefresh/jwtrefresh.go` (access-token constants + issuer used by this PR)
  - context keys in `constants/constants.go`
  - token TTL config fields in `config/config.go`
  - test helper `handler/test_helpers_test.go`

## Implementation Notes

- Revoked token lookup is done during authentication; revoked tokens return `401 Unauthorized`.
- Logout revokes the currently presented access token and clears auth cookies.
- Subject type (`admin`/`user`) is preserved in revocation records for scoped validation.
- Branch includes minimal auth compatibility fields/utilities required to keep token-revocation standalone on `develop`.

## Testing

Ran and passed:
- `go test ./handler`
- `cd resources/app && go test ./handler`
- `cd resources/app && go generate ./...`

## Acceptance Criteria Mapping

- Immediate logout invalidation: implemented
- Revoked-token request blocking: implemented
- Admin + app logout coverage: implemented
- Persistent revocation tracking: implemented
- Branch builds cleanly on `develop`: implemented
